### PR TITLE
Add healthcheck endpoint

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,6 +12,7 @@ metrics = GDSMetrics() # noqa
 
 from .download.views import download_blueprint
 from .upload.views import upload_blueprint
+from .healthcheck import healthcheck_blueprint
 
 
 def create_app():
@@ -27,5 +28,6 @@ def create_app():
 
     application.register_blueprint(download_blueprint)
     application.register_blueprint(upload_blueprint)
+    application.register_blueprint(healthcheck_blueprint)
 
     return application

--- a/app/healthcheck.py
+++ b/app/healthcheck.py
@@ -1,0 +1,10 @@
+from flask import Blueprint
+
+
+healthcheck_blueprint = Blueprint('healthcheck', __name__, url_prefix='')
+
+
+@healthcheck_blueprint.route('/')
+@healthcheck_blueprint.route('/_status')
+def status():
+    return "ok", 200

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -18,7 +18,7 @@ awscli-cwlogs>=1.4,<1.5
 
 gds-metrics==0.2.0
 
-git+https://github.com/cds-snc/notifier-utils.git@39.0.1#egg=notifications-utils==39.0.1
+git+https://github.com/cds-snc/notifier-utils.git@43.1.3#egg=notifications-utils==43.1.3
 
 socketio-client==0.5.6
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ awscli-cwlogs>=1.4,<1.5
 
 gds-metrics==0.2.0
 
-git+https://github.com/cds-snc/notifier-utils.git@39.0.1#egg=notifications-utils==39.0.1
+git+https://github.com/cds-snc/notifier-utils.git@43.1.3#egg=notifications-utils==43.1.3
 
 socketio-client==0.5.6
 requests

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    ['/', '/_status'],
+)
+def test_healthcheck_endpoint(client, endpoint):
+    response = client.get(endpoint)
+    assert response.status_code == 200


### PR DESCRIPTION
This repository does not have an healthcheck endpoint. This is a problem for Kubernetes/load balancers.

Adding one to `/_status` as other repositories and on the homepage