### PR TITLE
Align Docker sha size with other repos

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -18,10 +18,10 @@ jobs:
         gcloud auth configure-docker
     - name: Build
       run: |        
-        docker build -t gcr.io/cdssnc/notify/document-download-api:${GITHUB_SHA::8} -t gcr.io/cdssnc/notify/document-download-api:latest -f ci/Dockerfile .
+        docker build -t gcr.io/cdssnc/notify/document-download-api:${GITHUB_SHA::7} -t gcr.io/cdssnc/notify/document-download-api:latest -f ci/Dockerfile .
     - name: Publish
       run: |
-        docker push gcr.io/cdssnc/notify/document-download-api:latest && docker push gcr.io/cdssnc/notify/document-download-api:${GITHUB_SHA::8}
+        docker push gcr.io/cdssnc/notify/document-download-api:latest && docker push gcr.io/cdssnc/notify/document-download-api:${GITHUB_SHA::7}
     - name: EKS
       uses: docker://gcr.io/cdssnc/aws:latest
       env:
@@ -35,4 +35,4 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       with:
-        args: set image deployment.apps/document-download-api document-download-api=gcr.io/cdssnc/notify/document-download-api:${GITHUB_SHA::8} -n=notification-canada-ca --kubeconfig=/github/home/.kube/config
+        args: set image deployment.apps/document-download-api document-download-api=gcr.io/cdssnc/notify/document-download-api:${GITHUB_SHA::7} -n=notification-canada-ca --kubeconfig=/github/home/.kube/config


### PR DESCRIPTION
This repository is the only one using a SHA size of 8 characters at the moment

https://github.com/cds-snc/notification-manifests/blob/5bdecc878f39e94b4a4e0e00f0ba003a28951b51/env/production/kustomization.yaml#L12-L20

I'm aligning it with other repositories. I'll change the SHA after this is merged and then we'll be able to update the PR bot to automatically update document images as it does for admin + API.