### PR TITLE
feat: new MIME types and increase size

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -6,8 +6,8 @@ on:
 
 env:
   AWS_REGION: ca-central-1
-  DOCKER_ORG: public.ecr.aws/v6b8u5o6
-  DOCKER_SLUG: public.ecr.aws/v6b8u5o6/notify-document-download-api
+  DOCKER_ORG: public.ecr.aws/cds-snc
+  DOCKER_SLUG: public.ecr.aws/cds-snc/notify-document-download-api
   KUBECTL_VERSION: '1.18.0'
 
 jobs:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,15 +1,23 @@
 on: push
 name: Continuous Integration
 jobs:
-  build:
-    name: docker://python:3.6-stretch
+  test:
     runs-on: ubuntu-latest
+    container:
+      image: python:3.6-stretch
+
     steps:
-    - uses: actions/checkout@master
-    - name: docker://python:3.6-stretch
-      uses: docker://python:3.6-stretch
+    - uses: actions/checkout@v2
+
+    - uses: actions/cache@v2
       with:
-        entrypoint: /bin/bash
-        args: -c "pip3 install -r requirements-dev.txt && make test"
-    - name: docker://cdssnc/seekret-github-action
-      uses: docker://cdssnc/seekret-github-action
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements-dev.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      run: pip install -r requirements-dev.txt
+
+    - name: Run tests
+      run: make test

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,12 +2,19 @@ on: push
 name: Continuous Integration
 jobs:
   test:
+    name: docker://python:3.6-stretch
     runs-on: ubuntu-latest
-    container:
-      image: python:3.6-stretch
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+
+    - name: Upgrade pip
+      run: python -m pip install --upgrade pip
 
     - uses: actions/cache@v2
       with:

--- a/app/config.py
+++ b/app/config.py
@@ -17,9 +17,16 @@ class Config(metaclass=MetaFlaskEnv):
         'application/pdf',
         'text/csv',
         'text/plain',
+        'application/msword',  # .doc
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',  # .docx
+        'image/jpeg',
+        'image/png',
+        'application/vnd.ms-excel',  # .xls
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',  # .xlsx
+        'application/vnd.apple.numbers',  # "Numbers" app on macOS
     ]
 
-    MAX_CONTENT_LENGTH = 2 * 1024 * 1024 + 1024
+    MAX_CONTENT_LENGTH = 10 * 1024 * 1024 + 1024
 
     HTTP_SCHEME = os.getenv("HTTP_SCHEME", "http")
     FRONTEND_HOSTNAME = os.getenv("FRONTEND_HOSTNAME", "localhost:7001")

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -100,7 +100,7 @@ def test_document_upload_unknown_type(client):
 
     assert response.status_code == 400
     assert response.json == {
-        'error': "Unsupported document type 'application/octet-stream'. Supported types are: ['application/pdf', 'text/csv', 'text/plain']" # noqa
+        'error': "Unsupported document type 'application/octet-stream'. Supported types are: ['application/pdf', 'text/csv', 'text/plain', 'application/msword', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'image/jpeg', 'image/png', 'application/vnd.ms-excel', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'application/vnd.apple.numbers']" # noqa
     }
 
 
@@ -116,7 +116,7 @@ def test_document_file_size_just_right(client, store, antivirus):
         '/services/12345678-1111-1111-1111-123456789012/documents',
         content_type='multipart/form-data',
         data={
-            'document': (io.BytesIO(b'%PDF-1.5 ' + b'a' * (2 * 1024 * 1024 - 8)), 'file.pdf')
+            'document': (io.BytesIO(b'%PDF-1.5 ' + b'a' * (10 * 1024 * 1024 - 8)), 'file.pdf')
         }
     )
 
@@ -128,7 +128,7 @@ def test_document_file_size_too_large(client):
         '/services/12345678-1111-1111-1111-123456789012/documents',
         content_type='multipart/form-data',
         data={
-            'document': (io.BytesIO(b'pdf' * 1024 * 1024), 'file.pdf')
+            'document': (io.BytesIO(b'%PDF-1.5 ' + b'a' * 11 * 1024 * 1024), 'file.pdf')
         }
     )
 


### PR DESCRIPTION
Bump max size from 2MB to 10MB and add additional allowed MIME types

Trello card: https://trello.com/c/rFIqFtVq/241-allow-extra-mime-types-for-attachments