### PR TITLE
feat: allow extra MIME types per service ID

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -25,6 +25,7 @@ class Config(metaclass=MetaFlaskEnv):
         'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',  # .xlsx
         'application/vnd.apple.numbers',  # "Numbers" app on macOS
     ]
+    EXTRA_MIME_TYPES = os.getenv("EXTRA_MIME_TYPES", "")
 
     MAX_CONTENT_LENGTH = 10 * 1024 * 1024 + 1024
 

--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -16,7 +16,7 @@ def upload_document(service_id):
         return jsonify(error='No document upload'), 400
 
     mimetype = get_mime_type(request.files['document'])
-    if mimetype not in current_app.config['ALLOWED_MIME_TYPES']:
+    if not mime_type_is_allowed(mimetype, service_id):
         return jsonify(
             error="Unsupported document type '{}'. Supported types are: {}".format(
                 mimetype,
@@ -49,3 +49,13 @@ def upload_document(service_id):
             'mlwr_sid': sid
         }
     ), 201
+
+
+def mime_type_is_allowed(mimetype, service_id):
+    if mimetype in current_app.config['ALLOWED_MIME_TYPES']:
+        return True
+
+    # Payload is formatted like "service_id1:mime1,service_id2:mime2"
+    # Example:
+    # "fccd5d86-afd6-491b-afa8-2ff592e1404f:application/octet-stream,95365643-8126-46f1-a222-e0c51fa918f2:application/json"
+    return f"{service_id}:{mimetype}" in current_app.config['EXTRA_MIME_TYPES']


### PR DESCRIPTION
Add the possibility to allow extra MIME types on a per Notify service basis.

For now this is very simple, it's managed through a new environment variable, `EXTRA_MIME_TYPES`. Later it could be managed through Platform Admin.

The allowlist is here https://github.com/cds-snc/notification-document-download-api/blob/a4edb5a5984be248639e159ef584ce3cfa1a3b73/app/config.py#L16-L27 and setting `EXTRA_MIME_TYPES` to `12345678-1111-1111-1111-123456789012:application/octet-stream` will allow the service `12345678-1111-1111-1111-123456789012` to upload `application/octet-stream` documents (on top of the general list).