### PR TITLE
feat: handle filename argument

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -12,6 +12,8 @@ def download_document(service_id, document_id):
     if 'key' not in request.args:
         return jsonify(error='Missing decryption key'), 400
 
+    filename = request.args.get('filename')
+
     try:
         key = base64_to_bytes(request.args['key'])
     except ValueError:
@@ -29,7 +31,13 @@ def download_document(service_id, document_id):
         )
         return jsonify(error=str(e)), 400
 
-    response = make_response(send_file(document['body'], mimetype=document['mimetype']))
+    response = make_response(send_file(
+        document['body'],
+        mimetype=document['mimetype'],
+        # as_attachment can only be `True` if the filename is set
+        as_attachment=(filename is not None),
+        attachment_filename=filename,
+    ))
     response.headers['Content-Length'] = document['size']
     response.headers['X-Robots-Tag'] = 'noindex, nofollow'
 

--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -25,6 +25,13 @@ def upload_document(service_id):
         ), 400
     file_content = request.files['document'].read()
 
+    filename = request.form.get('filename')
+    # If the API passed None as an argument, it could be converted
+    # as a string value `None`. Convert it back to a proper None.
+    # See https://bugs.python.org/issue18857
+    if filename and filename.lower() == 'none':
+        filename = None
+
     if current_app.config["MLWR_HOST"]:
         sid = upload_to_mlwr(file_content)
     else:
@@ -45,8 +52,10 @@ def upload_document(service_id):
                 service_id=service_id,
                 document_id=document['id'],
                 key=document['encryption_key'],
+                filename=filename,
             ),
-            'mlwr_sid': sid
+            'mlwr_sid': sid,
+            'filename': filename,
         }
     ), 201
 

--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -26,11 +26,6 @@ def upload_document(service_id):
     file_content = request.files['document'].read()
 
     filename = request.form.get('filename')
-    # If the API passed None as an argument, it could be converted
-    # as a string value `None`. Convert it back to a proper None.
-    # See https://bugs.python.org/issue18857
-    if filename and filename.lower() == 'none':
-        filename = None
 
     if current_app.config["MLWR_HOST"]:
         sid = upload_to_mlwr(file_content)

--- a/app/utils/urls.py
+++ b/app/utils/urls.py
@@ -14,10 +14,11 @@ def get_direct_file_url(service_id, document_id, key):
     )
 
 
-def get_frontend_download_url(service_id, document_id, key):
+def get_frontend_download_url(service_id, document_id, key, filename):
     scheme = current_app.config['HTTP_SCHEME']
     netloc = current_app.config['FRONTEND_HOSTNAME']
     path = 'd/{}/{}'.format(uuid_to_base64(service_id), uuid_to_base64(document_id))
-    query = urlencode({'key': bytes_to_base64(key)})
+    query_params = {'key': bytes_to_base64(key), 'filename': filename}
+    query = urlencode({k: v for k, v in query_params.items() if v})
 
     return urlunsplit([scheme, netloc, path, query, None])

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -18,9 +18,6 @@ def antivirus(mocker):
 
 @pytest.mark.parametrize(
     "request_includes_filename, filename, in_frontend_url, expected_filename", [
-        (True, None, False, None),
-        (True, 'none', False, None),
-        (True, 'None', False, None),
         (True, 'custom_filename.pdf', True, 'custom_filename.pdf'),
         (False, 'whatever', False, None),
     ]

--- a/tests/utils/test_urls.py
+++ b/tests/utils/test_urls.py
@@ -8,10 +8,22 @@ SAMPLE_KEY = bytes(range(32))
 SAMPLE_B64 = 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8'
 
 
-def test_get_frontend_download_url_returns_frontend_url(app):
+def test_get_frontend_download_url_returns_frontend_url_without_filename(app):
     assert get_frontend_download_url(
-        service_id=UUID(int=0), document_id=UUID(int=1), key=SAMPLE_KEY
+        service_id=UUID(int=0), document_id=UUID(int=1), key=SAMPLE_KEY,
+        filename=None
     ) == 'http://localhost:7001/d/{}/{}?key={}'.format(
+        'AAAAAAAAAAAAAAAAAAAAAA',
+        'AAAAAAAAAAAAAAAAAAAAAQ',
+        SAMPLE_B64
+    )
+
+
+def test_get_frontend_download_url_returns_frontend_url_with_filename(app):
+    assert get_frontend_download_url(
+        service_id=UUID(int=0), document_id=UUID(int=1), key=SAMPLE_KEY,
+        filename='file.pdf'
+    ) == 'http://localhost:7001/d/{}/{}?key={}&filename=file.pdf'.format(
         'AAAAAAAAAAAAAAAAAAAAAA',
         'AAAAAAAAAAAAAAAAAAAAAQ',
         SAMPLE_B64


### PR DESCRIPTION
## Story
When attaching files to my email notification I want to be able to set the file name programmatically so that my recipients don't get files named with long strings of numbers and letters that aren't a11y friendly. 

## What it does

- Handles the `filename` argument passed from the Notify API. Will be implemented in https://github.com/cds-snc/notification-api/pull/1249
- Pass the `filename` argument to the document download frontend if it set. This will be used when people will download files from the UI (when attachments are linked)
- If the `filename` argument is present, download the attachment using this filename

Trello card: https://trello.com/c/BVIe44l5/443-let-clients-name-the-files-they-are-attaching-in-the-api