### PR TITLE
Link or attachment api

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -13,6 +13,7 @@ def download_document(service_id, document_id):
         return jsonify(error='Missing decryption key'), 400
 
     filename = request.args.get('filename')
+    sending_method = request.args.get('sending_method')
 
     try:
         key = base64_to_bytes(request.args['key'])
@@ -20,7 +21,7 @@ def download_document(service_id, document_id):
         return jsonify(error='Invalid decryption key'), 400
 
     try:
-        document = document_store.get(service_id, document_id, key)
+        document = document_store.get(service_id, document_id, key, sending_method)
     except DocumentStoreError as e:
         current_app.logger.info(
             'Failed to download document: {}'.format(e),

--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -27,12 +27,14 @@ def upload_document(service_id):
 
     filename = request.form.get('filename')
 
+    sending_method = request.form.get('sending_method')
+
     if current_app.config["MLWR_HOST"]:
         sid = upload_to_mlwr(file_content)
     else:
         sid = False
 
-    document = document_store.put(service_id, file_content, mimetype=mimetype)
+    document = document_store.put(service_id, file_content, sending_method=sending_method, mimetype=mimetype)
 
     return jsonify(
         status='ok',
@@ -42,6 +44,7 @@ def upload_document(service_id):
                 service_id=service_id,
                 document_id=document['id'],
                 key=document['encryption_key'],
+                sending_method=sending_method,
             ),
             'url': get_frontend_download_url(
                 service_id=service_id,
@@ -51,6 +54,7 @@ def upload_document(service_id):
             ),
             'mlwr_sid': sid,
             'filename': filename,
+            'sending_method': sending_method,
         }
     ), 201
 

--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -17,7 +17,7 @@ class DocumentStore:
     def init_app(self, app):
         self.bucket = app.config['DOCUMENTS_BUCKET']
 
-    def put(self, service_id, document_stream, *, sending_method, mimetype='application/pdf'):
+    def put(self, service_id, document_stream, sending_method, mimetype='application/pdf'):
         """
         returns dict {'id': 'some-uuid', 'encryption_key': b'32 byte encryption key'}
         """
@@ -65,4 +65,4 @@ class DocumentStore:
 
     def get_document_key(self, service_id, document_id, sending_method=None):
         key_prefix = 'tmp/' if sending_method == 'attach' else ''
-        return f"{key_prefix}{service_id}/{document_id}".
+        return f"{key_prefix}{service_id}/{document_id}"

--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -17,7 +17,7 @@ class DocumentStore:
     def init_app(self, app):
         self.bucket = app.config['DOCUMENTS_BUCKET']
 
-    def put(self, service_id, document_stream, *, mimetype='application/pdf'):
+    def put(self, service_id, document_stream, *, sending_method, mimetype='application/pdf'):
         """
         returns dict {'id': 'some-uuid', 'encryption_key': b'32 byte encryption key'}
         """
@@ -27,7 +27,7 @@ class DocumentStore:
 
         self.s3.put_object(
             Bucket=self.bucket,
-            Key=self.get_document_key(service_id, document_id),
+            Key=self.get_document_key(service_id, document_id, sending_method),
             Body=document_stream,
             ContentType=mimetype,
             SSECustomerKey=encryption_key,
@@ -39,14 +39,14 @@ class DocumentStore:
             'encryption_key': encryption_key
         }
 
-    def get(self, service_id, document_id, decryption_key):
+    def get(self, service_id, document_id, decryption_key, sending_method):
         """
         decryption_key should be raw bytes
         """
         try:
             document = self.s3.get_object(
                 Bucket=self.bucket,
-                Key=self.get_document_key(service_id, document_id),
+                Key=self.get_document_key(service_id, document_id, sending_method),
                 SSECustomerKey=decryption_key,
                 SSECustomerAlgorithm='AES256'
             )
@@ -63,5 +63,6 @@ class DocumentStore:
     def generate_encryption_key(self):
         return os.urandom(32)
 
-    def get_document_key(self, service_id, document_id):
-        return "{}/{}".format(service_id, document_id)
+    def get_document_key(self, service_id, document_id, sending_method=None):
+        key_prefix = 'tmp/' if sending_method == 'attach' else ''
+        return "{}{}/{}".format(key_prefix, service_id, document_id)

--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -65,4 +65,4 @@ class DocumentStore:
 
     def get_document_key(self, service_id, document_id, sending_method=None):
         key_prefix = 'tmp/' if sending_method == 'attach' else ''
-        return "{}{}/{}".format(key_prefix, service_id, document_id)
+        return f"{key_prefix}{service_id}/{document_id}".

--- a/app/utils/urls.py
+++ b/app/utils/urls.py
@@ -4,12 +4,13 @@ from flask import current_app, url_for
 from notifications_utils.base64_uuid import bytes_to_base64, uuid_to_base64
 
 
-def get_direct_file_url(service_id, document_id, key):
+def get_direct_file_url(service_id, document_id, key, sending_method):
     return url_for(
         'download.download_document',
         service_id=service_id,
         document_id=document_id,
         key=bytes_to_base64(key),
+        sending_method=sending_method,
         _external=True
     )
 

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -43,7 +43,8 @@ def test_document_download(client, store):
     store.get.assert_called_once_with(
         UUID('00000000-0000-0000-0000-000000000000'),
         UUID('ffffffff-ffff-ffff-ffff-ffffffffffff'),
-        bytes(32)
+        bytes(32),
+        None
     )
 
 
@@ -79,7 +80,8 @@ def test_document_download_with_filename(client, store):
     store.get.assert_called_once_with(
         UUID('00000000-0000-0000-0000-000000000000'),
         UUID('ffffffff-ffff-ffff-ffff-ffffffffffff'),
-        bytes(32)
+        bytes(32),
+        None
     )
 
 

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -17,9 +17,9 @@ def antivirus(mocker):
 
 
 @pytest.mark.parametrize(
-    "request_includes_filename, filename, in_frontend_url, expected_filename", [
-        (True, 'custom_filename.pdf', True, 'custom_filename.pdf'),
-        (False, 'whatever', False, None),
+    "request_includes_filename, filename, in_frontend_url, expected_filename, sending_method", [
+        (True, 'custom_filename.pdf', True, 'custom_filename.pdf', 'attach'),
+        (False, 'whatever', False, None, 'link'),
     ]
 )
 def test_document_upload_returns_link_to_frontend(
@@ -30,6 +30,7 @@ def test_document_upload_returns_link_to_frontend(
     filename,
     in_frontend_url,
     expected_filename,
+    sending_method,
 ):
     store.put.return_value = {
         'id': 'ffffffff-ffff-ffff-ffff-ffffffffffff',
@@ -38,6 +39,7 @@ def test_document_upload_returns_link_to_frontend(
     antivirus.return_value = "abcd"
     data = {
         'document': (io.BytesIO(b'%PDF-1.4 file contents'), 'file.pdf'),
+        'sending_method': sending_method
     }
 
     frontend_url_parts = [
@@ -69,9 +71,11 @@ def test_document_upload_returns_link_to_frontend(
                 '/services/00000000-0000-0000-0000-000000000000',
                 '/documents/ffffffff-ffff-ffff-ffff-ffffffffffff',
                 '?key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+                f'&sending_method={sending_method}'
             ]),
             'mlwr_sid': 'abcd',
             'filename': expected_filename,
+            'sending_method': sending_method
         },
         'status': 'ok'
     }

--- a/tests/utils/test_urls.py
+++ b/tests/utils/test_urls.py
@@ -32,9 +32,11 @@ def test_get_frontend_download_url_returns_frontend_url_with_filename(app):
 
 def test_get_direct_file_url_gets_local_url_without_compressing_uuids(app):
     assert get_direct_file_url(
-        service_id=UUID(int=0), document_id=UUID(int=1), key=SAMPLE_KEY
-    ) == 'http://document-download.test/services/{}/documents/{}?key={}'.format(
+        service_id=UUID(int=0), document_id=UUID(int=1), key=SAMPLE_KEY,
+        sending_method='link'
+    ) == 'http://document-download.test/services/{}/documents/{}?key={}&sending_method={}'.format(
         '00000000-0000-0000-0000-000000000000',
         '00000000-0000-0000-0000-000000000001',
-        SAMPLE_B64
+        SAMPLE_B64,
+        'link'
     )


### PR DESCRIPTION
Trello:
https://trello.com/c/wtkWVPcA/369-let-clients-attach-files-directly-to-emails-with-the-api

Related PRs:
https://github.com/cds-snc/notification-terraform/pull/224
https://github.com/cds-snc/notification-documentation/pull/70
https://github.com/cds-snc/notification-api/pull/1254

Adds support for sending_method parameter from notification-api to determine which S3 bucket to this app should store the file to.

Parameter is optional to maintain backwards compatibility as well as fall back to linking method when using this API.