### PR TITLE
feat: add size and mime when uploading documents

### DIFF
--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -1,3 +1,5 @@
+import pathlib
+
 from flask import Blueprint, current_app, jsonify, request
 
 from app import document_store
@@ -26,6 +28,9 @@ def upload_document(service_id):
     file_content = request.files['document'].read()
 
     filename = request.form.get('filename')
+    file_extension = None
+    if filename and '.' in filename:
+        file_extension = ''.join(pathlib.Path(filename).suffixes).lstrip('.')
 
     sending_method = request.form.get('sending_method')
 
@@ -57,6 +62,7 @@ def upload_document(service_id):
             'sending_method': sending_method,
             'mime_type': mimetype,
             'file_size': len(file_content),
+            'file_extension': file_extension,
         }
     ), 201
 

--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -55,6 +55,8 @@ def upload_document(service_id):
             'mlwr_sid': sid,
             'filename': filename,
             'sending_method': sending_method,
+            'mime_type': mimetype,
+            'file_size': len(file_content),
         }
     ), 201
 

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -49,8 +49,10 @@ def test_document_upload_returns_link_to_frontend(
         '?key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
     ]
 
+    expected_extension = None
     if request_includes_filename:
         data['filename'] = filename
+        expected_extension = filename.split('.')[-1]
 
     if in_frontend_url:
         frontend_url_parts.append(f'&filename={filename}')
@@ -77,16 +79,18 @@ def test_document_upload_returns_link_to_frontend(
             'filename': expected_filename,
             'sending_method': sending_method,
             'mime_type': 'application/pdf',
-            'file_size': 22
+            'file_size': 22,
+            'file_extension': expected_extension
         },
         'status': 'ok'
     }
 
 
 @pytest.mark.parametrize(
-    "content, expected_mime, expected_size", [
-        (b'%PDF-1.4 file contents', 'application/pdf', 22),
-        (b'Canada', 'text/plain', 6),
+    "content, filename, expected_extension, expected_mime, expected_size", [
+        (b'%PDF-1.4 file contents', 'file.pdf', 'pdf', 'application/pdf', 22),
+        (b'Canada', 'text.txt', 'txt', 'text/plain', 6),
+        (b'Canada', 'noextension', None, 'text/plain', 6),
     ]
 )
 def test_document_upload_returns_size_and_mime(
@@ -94,6 +98,8 @@ def test_document_upload_returns_size_and_mime(
     store,
     antivirus,
     content,
+    filename,
+    expected_extension,
     expected_mime,
     expected_size
 ):
@@ -108,13 +114,15 @@ def test_document_upload_returns_size_and_mime(
         content_type='multipart/form-data',
         data={
             'document': (io.BytesIO(content), 'file.pdf'),
-            'sending_method': 'link'
+            'sending_method': 'link',
+            'filename': filename,
         }
     )
 
     assert response.status_code == 201
     assert response.json['document']['mime_type'] == expected_mime
     assert response.json['document']['file_size'] == expected_size
+    assert response.json['document']['file_extension'] == expected_extension
 
 
 @pytest.mark.skip(reason="NO AV")

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -113,7 +113,7 @@ def test_document_upload_returns_size_and_mime(
         '/services/00000000-0000-0000-0000-000000000000/documents',
         content_type='multipart/form-data',
         data={
-            'document': (io.BytesIO(content), 'file.pdf'),
+            'document': (io.BytesIO(content), filename),
             'sending_method': 'link',
             'filename': filename,
         }


### PR DESCRIPTION
Return some metadata about file size, file extension and the mime type when uploading documents.

Those fields will be used by the Notify API to collect stats about attachments. This codebase already reads the file so it seems like an appropriate place to output these values.