### PR TITLE
feat: improve MIME detection for CSV files

### DIFF
--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -30,11 +30,11 @@ def upload_document(service_id):
     filename = request.form.get('filename')
     file_extension = None
     if filename and '.' in filename:
-        file_extension = ''.join(pathlib.Path(filename).suffixes).lstrip('.')
+        file_extension = ''.join(pathlib.Path(filename.lower()).suffixes).lstrip('.')
 
     # Our MIME type auto-detection resolves CSV content as text/plain,
     # so we use fix that if possible
-    if (filename or '').endswith('.csv') and mimetype == 'text/plain':
+    if (filename or '').lower().endswith('.csv') and mimetype == 'text/plain':
         mimetype = 'text/csv'
 
     sending_method = request.form.get('sending_method')

--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -33,7 +33,7 @@ def upload_document(service_id):
         file_extension = ''.join(pathlib.Path(filename.lower()).suffixes).lstrip('.')
 
     # Our MIME type auto-detection resolves CSV content as text/plain,
-    # so we use fix that if possible
+    # so we fix that if possible
     if (filename or '').lower().endswith('.csv') and mimetype == 'text/plain':
         mimetype = 'text/csv'
 

--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -32,6 +32,11 @@ def upload_document(service_id):
     if filename and '.' in filename:
         file_extension = ''.join(pathlib.Path(filename).suffixes).lstrip('.')
 
+    # Our MIME type auto-detection resolves CSV content as text/plain,
+    # so we use fix that if possible
+    if (filename or '').endswith('.csv') and mimetype == 'text/plain':
+        mimetype = 'text/csv'
+
     sending_method = request.form.get('sending_method')
 
     if current_app.config["MLWR_HOST"]:

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -91,6 +91,7 @@ def test_document_upload_returns_link_to_frontend(
         (b'%PDF-1.4 file contents', 'file.pdf', 'pdf', 'application/pdf', 22),
         (b'Canada', 'text.txt', 'txt', 'text/plain', 6),
         (b'Canada', 'noextension', None, 'text/plain', 6),
+        (b'foo,bar', 'file.csv', 'csv', 'text/csv', 7),
     ]
 )
 def test_document_upload_returns_size_and_mime(

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -92,6 +92,8 @@ def test_document_upload_returns_link_to_frontend(
         (b'Canada', 'text.txt', 'txt', 'text/plain', 6),
         (b'Canada', 'noextension', None, 'text/plain', 6),
         (b'foo,bar', 'file.csv', 'csv', 'text/csv', 7),
+        (b'foo,bar', 'FILE.CSV', 'csv', 'text/csv', 7),
+        (b'foo,bar', None, None, 'text/plain', 7),
     ]
 )
 def test_document_upload_returns_size_and_mime(
@@ -114,7 +116,7 @@ def test_document_upload_returns_size_and_mime(
         '/services/00000000-0000-0000-0000-000000000000/documents',
         content_type='multipart/form-data',
         data={
-            'document': (io.BytesIO(content), filename),
+            'document': (io.BytesIO(content), filename or 'fake'),
             'sending_method': 'link',
             'filename': filename,
         }


### PR DESCRIPTION
Set an appropriate MIME type for CSV files. CSV files are really plain text files so it's "impossible" to detect the MIME type automatically. Use the filename argument if present to set the appropriate MIME type.

GDS also has this problem and they handle this with a `is_csv` argument because they don't pass filenames. https://github.com/alphagov/document-download-api/blob/fa865117606eb63f0fdde3f2b3a353c51f1b4bbd/app/upload/views.py#L42-L45