### PR TITLE
fix: urlencode to the frontend app

### DIFF
--- a/app/utils/urls.py
+++ b/app/utils/urls.py
@@ -1,4 +1,4 @@
-from urllib.parse import urlunsplit, urlencode
+from urllib.parse import quote, urlunsplit, urlencode
 
 from flask import current_app, url_for
 from notifications_utils.base64_uuid import bytes_to_base64, uuid_to_base64
@@ -20,6 +20,9 @@ def get_frontend_download_url(service_id, document_id, key, filename):
     netloc = current_app.config['FRONTEND_HOSTNAME']
     path = 'd/{}/{}'.format(uuid_to_base64(service_id), uuid_to_base64(document_id))
     query_params = {'key': bytes_to_base64(key), 'filename': filename}
-    query = urlencode({k: v for k, v in query_params.items() if v})
+    query = urlencode(
+        {k: v for k, v in query_params.items() if v},
+        quote_via=quote
+    )
 
     return urlunsplit([scheme, netloc, path, query, None])

--- a/tests/utils/test_urls.py
+++ b/tests/utils/test_urls.py
@@ -22,8 +22,8 @@ def test_get_frontend_download_url_returns_frontend_url_without_filename(app):
 def test_get_frontend_download_url_returns_frontend_url_with_filename(app):
     assert get_frontend_download_url(
         service_id=UUID(int=0), document_id=UUID(int=1), key=SAMPLE_KEY,
-        filename='file.pdf'
-    ) == 'http://localhost:7001/d/{}/{}?key={}&filename=file.pdf'.format(
+        filename="ça va.pdf"
+    ) == 'http://localhost:7001/d/{}/{}?key={}&filename=%C3%A7a%20va.pdf'.format(
         'AAAAAAAAAAAAAAAAAAAAAA',
         'AAAAAAAAAAAAAAAAAAAAAQ',
         SAMPLE_B64


### PR DESCRIPTION
Fix the URL encoding logic. Filenames with spaces were encoded with a `+` like `hello+world.pdf` and somehow the frontend did not like that. Switching spaces to `%20`.

It seems it's [the recommend way](https://stackoverflow.com/a/1634293) for URLs. Confirmed that changing to this value works (am happy to share URLs with you).