### PR TITLE
Updating the .env example file with sensible defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+NOTIFY_ENVIRONMENT = 'development'
 DEBUG = True
 
 SECRET_KEY = 'secret-key'
@@ -18,7 +19,3 @@ NOTIFY_LOG_PATH = 'application.log'
 FLASK_APP=application.py
 FLASK_DEBUG=1
 WERKZEUG_DEBUG_PIN=off
-
-AWS_REGION=us-east-1
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=


### PR DESCRIPTION
# Summary | Résumé

I need the `NOTIFY_ENVIRONMENT` to be defined for the new Waffle script and have it set at a `development` value.

# Test instructions | Instructions pour tester la modification

This should not affect any existing infra or logic.
