### PR TITLE
Increase buffer size to detect mime type.

### DIFF
--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -3,7 +3,7 @@ import magic
 
 def get_mime_type(document_stream):
     try:
-        mime_type = magic.from_buffer(document_stream.read(1024), mime=True)
+        mime_type = magic.from_buffer(document_stream.read(2048), mime=True)
     finally:
         document_stream.seek(0)
 


### PR DESCRIPTION
# Summary | Résumé

Addressing issue raised by the forms team with excel files being incorrectly detected as `application/zip` instead of expected and allowed `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`.

## Debugging session

Okay, after setting up my vscode to debug the document-download-api through the alpine/python3-6 image remotely through docker (that was pain).. I found out an interesting behavior.

First, from the docker image, without the python flask app loaded but directly using a Python interpreter:

```python
>>> magic.from_file("CombinedFantasyRankings.xlsx")
'Microsoft Excel 2007+'
```

Hmm seems kinda ok, not the exact expected mimetype but not an `application/zip`. 

Let's try to do it the same through docker image and the Flask app loaded, using exactly the same context this time:

```python
> magic.from_buffer(document_stream.read(1024), mime=True)
'application/zip'
```

Hmm not cool, but hey.. we are using a buffer here and it seems a bit limited, let's try to increase it:

```python
> magic.from_buffer(document_stream.read(2048), mime=True)
'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
```

Alrighty, working this time! 

That was fairly quick to fix, but the setup took time. That will definitely be useful for next time though. Hit me up if you want to know the proper VSCode setup: it involves remote containers, tasks and launcher configurations.

# Test instructions | Instructions pour tester la modification

I could write a unit tests with this specific scenario, but I wanted to offer a quick fix first.
