### PR TITLE
feat: add config logging on service start

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,36 @@
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.9
+
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install \
+        curl \
+        emacs \
+        exa \
+        fd-find \
+        git \ 
+        iproute2 \
+        less \
+        libmagic-dev \
+        libsodium-dev \
+        lsb-release \ 
+        man-db \
+        manpages \
+        net-tools \
+        nodejs \ 
+        npm \
+        openssh-client \ 
+        procps \ 
+        sudo \
+        tldr \
+        unzip \
+        vim \
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Upgrade pip
+RUN pip install --upgrade pip
+
+COPY .devcontainer/scripts/notify-dev-entrypoint.sh /usr/local/bin/
+
+EXPOSE 6012

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+{
+	"name": "notification-document-download-api",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": ".."
+	},
+
+	"remoteEnv": {
+		"PATH": "/home/vscode/.local/bin:${containerEnv:PATH}" // give our installed Python modules precedence
+	},
+
+	"containerEnv": {
+		"SHELL": "/bin/zsh"
+	},
+
+	"settings": { 
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.linting.pylintPath": "/usr/local/bin/pylint",
+		"python.pythonPath": "/usr/local/bin/python",
+	},
+
+	"extensions": [
+		"ms-python.python",		
+		"eamodio.gitlens",
+		"GitHub.copilot",
+	],
+
+	"forwardPorts": [7000],
+	"postCreateCommand": "notify-dev-entrypoint.sh",
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/scripts/notify-dev-entrypoint.sh
+++ b/.devcontainer/scripts/notify-dev-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -ex 
+
+###################################################################
+# This script will get executed *once* the Docker container has 
+# been built. Commands that need to be executed with all available
+# tools and the filesystem mount enabled should be located here. 
+###################################################################
+
+# Define aliases
+echo -e "\n\n# User's Aliases" >> ~/.zshrc
+echo -e "alias fd=fdfind" >> ~/.zshrc
+echo -e "alias l='ls -al --color'" >> ~/.zshrc
+echo -e "alias ls='exa'" >> ~/.zshrc
+echo -e "alias l='exa -alh'" >> ~/.zshrc
+echo -e "alias ll='exa -alh@ --git'" >> ~/.zshrc
+echo -e "alias lt='exa -al -T -L 2'" >> ~/.zshrc
+
+# Warm up git index prior to display status in prompt else it will 
+# be quite slow on every invocation of starship.
+git status
+
+pip3 install -r requirements.txt
+pip3 install -r requirements-dev.txt

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -16,8 +16,10 @@ from .healthcheck import healthcheck_blueprint
 
 
 def create_app():
+    config = configs[os.environ['NOTIFY_ENVIRONMENT']]
+
     application = Flask('app', static_folder=None)
-    application.config.from_object(configs[os.environ['NOTIFY_ENVIRONMENT']])
+    application.config.from_object(config)
 
     request_helper.init_app(application)
     logging.init_app(application)
@@ -28,5 +30,7 @@ def create_app():
     application.register_blueprint(download_blueprint)
     application.register_blueprint(upload_blueprint)
     application.register_blueprint(healthcheck_blueprint)
+
+    application.logger.info(f"Notify config: {config.get_safe_config()}")
 
     return application

--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,7 @@
 import os
 from flask_env import MetaFlaskEnv
 from dotenv import load_dotenv
+from notifications_utils import logging
 
 load_dotenv()
 
@@ -41,6 +42,22 @@ class Config(metaclass=MetaFlaskEnv):
     MLWR_HOST = os.getenv("MLWR_HOST", False)
     MLWR_USER = os.getenv("MLWR_USER", "")
     MLWR_KEY = os.getenv("MLWR_KEY", "")
+
+    @classmethod
+    def get_sensitive_config(cls) -> list[str]:
+        "List of config keys that contain sensitive information"
+        return [
+            "ANTIVIRUS_API_KEY",
+            "AUTH_TOKENS",
+            "MLWR_KEY",
+            "MLWR_USER",
+            "SECRET_KEY",
+        ]
+
+    @classmethod
+    def get_safe_config(cls) -> dict:
+        "Returns a dict of config keys and values with sensitive values masked"
+        return logging.get_class_attrs(cls, cls.get_sensitive_config())
 
 
 class Test(Config):

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -14,7 +14,7 @@ eventlet==0.28.0
 
 awscli-cwlogs>=1.4.6,<1.5
 
-git+https://github.com/cds-snc/notifier-utils.git@46.3.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@46.5.0#egg=notifications-utils
 
 socketio-client==0.5.6
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ eventlet==0.28.0
 
 awscli-cwlogs>=1.4.6,<1.5
 
-git+https://github.com/cds-snc/notifier-utils.git@46.3.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@46.5.0#egg=notifications-utils
 
 socketio-client==0.5.6
 requests

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,35 @@
+import importlib
+import os
+
+import pytest
+
+from app import config
+
+
+@pytest.fixture
+def reload_config():
+    """
+    Reset config, by simply re-running config.py from a fresh environment
+    """
+    old_env = os.environ.copy()
+
+    yield
+
+    os.environ = old_env
+    importlib.reload(config)
+
+
+def test_get_safe_config(mocker, reload_config):
+    mock_get_class_attrs = mocker.patch("notifications_utils.logging.get_class_attrs")
+    mock_get_sensitive_config = mocker.patch("app.config.Config.get_sensitive_config")
+
+    config.Config.get_safe_config()
+    assert mock_get_class_attrs.called
+    assert mock_get_sensitive_config.called
+
+
+def test_get_sensitive_config():
+    sensitive_config = config.Config.get_sensitive_config()
+    assert sensitive_config
+    for key in sensitive_config:
+        assert key


### PR DESCRIPTION
# Summary
Add config logging when the service starts so that
its configuration can be validated.

Also adds a devcontainer.

# Related
* cds-snc/notification-utils#118
* cds-snc/notification-planning#504