### PR TITLE
Upgrade to python 3.9 and flask 2.0.3

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.6
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.9
 
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils 2>&1 \

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,10 +7,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.9
     - name: Upgrade pip
       run: python -m pip install --upgrade pip
 
@@ -31,7 +31,7 @@ jobs:
         python_version=$(python  -V | cut -d' ' -f2)
         echo "python_version=${python_version}" >> $GITHUB_ENV
     - name: Copy site-packages in workspace
-      working-directory: /opt/hostedtoolcache/Python/${{ env.python_version }}/x64/lib/python3.6/
+      working-directory: /opt/hostedtoolcache/Python/${{ env.python_version }}/x64/lib/python3.9/
       shell: bash
       run: |
         mkdir -p "${{ github.workspace }}/env/" && cp -fR site-packages "${{ github.workspace }}/env/"

--- a/app/download/views.py
+++ b/app/download/views.py
@@ -37,7 +37,7 @@ def download_document(service_id, document_id):
         mimetype=document['mimetype'],
         # as_attachment can only be `True` if the filename is set
         as_attachment=(filename is not None),
-        attachment_filename=filename,
+        download_name=filename,
     ))
     response.headers['Content-Length'] = document['size']
     response.headers['X-Robots-Tag'] = 'noindex, nofollow'

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.9-alpine
 
 ENV PYTHONDONTWRITEBYTECODE 1
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -1,7 +1,7 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==1.0.3
+Flask==2.0.3
 Flask-Env==2.0.0
 
 python-dotenv==0.10.3
@@ -14,7 +14,7 @@ eventlet==0.28.0
 
 awscli-cwlogs>=1.4.6,<1.5
 
-git+https://github.com/cds-snc/notifier-utils.git@46.3.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@48.0.0#egg=notifications-utils
 
 socketio-client==0.5.6
 requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,13 +2,13 @@
 
 flake8==3.7.7
 
-pytest==4.6.1
+pytest==7.1.2
 pytest-env==0.6.2
-pytest-mock==1.10.4
-pytest-cov==2.7.1
+pytest-mock==3.7.0
+pytest-cov==3.0.0
 
-requests-mock==1.6.0
+requests-mock==1.9.3
 
-coveralls==1.8.0
+coveralls==1.11.0
 
-jinja2-cli[yaml]==0.7.0
+jinja2-cli[yaml]==0.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements-app.txt
 
-Flask==1.0.3
+Flask==2.0.3
 Flask-Env==2.0.0
 
 python-dotenv==0.10.3
@@ -15,7 +15,7 @@ eventlet==0.28.0
 
 awscli-cwlogs>=1.4.6,<1.5
 
-git+https://github.com/cds-snc/notifier-utils.git@46.3.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@48.0.0#egg=notifications-utils
 
 socketio-client==0.5.6
 requests
@@ -26,50 +26,51 @@ git+https://bitbucket.org/cse-assemblyline/assemblyline_client.git@v3.7.3#egg=as
 
 
 ## The following requirements were added by pip freeze:
+async-timeout==4.0.2
 awscli==1.19.58
 bleach==3.3.0
-blinker==1.4
 boto3==1.17.58
 botocore==1.20.58
 cachetools==4.2.1
-certifi==2021.10.8
-cffi==1.15.0
+certifi==2022.6.15
+cffi==1.15.1
 chardet==4.0.0
-click==8.0.3
+click==8.1.3
 colorama==0.4.3
-cryptography==35.0.0
+cryptography==37.0.4
+Deprecated==1.2.13
 dnspython==1.16.0
 docutils==0.15.2
 flask-redis==0.4.0
 greenlet==1.1.2
 idna==2.10
 itsdangerous==2.0.1
-Jinja2==2.11.3
+Jinja2==3.1.2
 jmespath==0.10.0
 MarkupSafe==2.0.1
 mistune==0.8.4
 monotonic==1.6
 orderedset==2.0.3
-packaging==21.0
+packaging==21.3
 phonenumbers==8.12.21
-prometheus-client==0.2.0
 py-w3c==0.3.1
 pyasn1==0.4.8
-pycparser==2.20
-pyOpenSSL==21.0.0
-pyparsing==2.4.7
+pycparser==2.21
+pyOpenSSL==22.0.0
+pyparsing==3.0.9
 PyPDF2==1.26.0
 python-dateutil==2.8.2
 python-json-logger==2.0.1
 pytz==2021.1
 PyYAML==5.4.1
-redis==3.5.3
+redis==4.3.4
 rsa==4.7.2
 s3transfer==0.4.2
 six==1.16.0
 smartypants==2.0.1
 statsd==3.3.0
-urllib3==1.26.7
+urllib3==1.26.10
 webencodings==0.5.1
-websocket-client==1.2.1
+websocket-client==1.3.3
 Werkzeug==2.0.2
+wrapt==1.14.1

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.8
+python-3.9.1

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -33,7 +33,7 @@ def test_document_download(client, store):
     assert response.get_data() == b'PDF document contents'
     assert dict(response.headers) == {
         'Cache-Control': mock.ANY,
-        'Expires': mock.ANY,
+        'Date': mock.ANY,
         'Content-Length': '100',
         'Content-Type': 'application/pdf',
         'X-B3-SpanId': 'None',
@@ -69,7 +69,7 @@ def test_document_download_with_filename(client, store):
     assert response.get_data() == b'PDF document contents'
     assert dict(response.headers) == {
         'Cache-Control': mock.ANY,
-        'Expires': mock.ANY,
+        'Date': mock.ANY,
         'Content-Length': '100',
         'Content-Type': 'application/pdf',
         'X-B3-SpanId': 'None',


### PR DESCRIPTION
# Summary | Résumé

This PR updates this repo to use python 3.9 to match the rest of our repos.  It also updates to flask 2.0.3 to finish of the flask/werkzeug upgrade work.

Changes:
- Updated python, flask, and accompanying libraries.
- Updated pytest, and other testing utils
- Updates the `flask.send_file()` parameters as one has been renamed and will soon be deprecated
- Fixes tests that fail with the new flask/werkzeug.  It seems instead of an `expires` header it is now returning a `date` header.