### PR TITLE
send new api file link to end users

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ MLWR_KEY=''
 
 HTTP_SCHEME = 'http'
 FRONTEND_HOSTNAME = 'localhost:7001'
+BACKEND_HOSTNAME = 'localhost:7000'
 
 NOTIFY_APP_NAME = 'Name'
 NOTIFY_LOG_PATH = 'application.log'

--- a/app/config.py
+++ b/app/config.py
@@ -31,6 +31,7 @@ class Config(metaclass=MetaFlaskEnv):
 
     HTTP_SCHEME = os.getenv("HTTP_SCHEME", "http")
     FRONTEND_HOSTNAME = os.getenv("FRONTEND_HOSTNAME", "localhost:7001")
+    BACKEND_HOSTNAME = os.getenv("BACKEND_HOSTNAME", "localhost:7000")
 
     NOTIFY_APP_NAME = os.getenv("NOTIFY_APP_NAME", "Name")
     NOTIFY_LOG_PATH = os.getenv("NOTIFY_LOG_PATH", "application.log")
@@ -58,6 +59,8 @@ class Test(Config):
     ANTIVIRUS_API_KEY = 'test-antivirus-secret'
 
     FRONTEND_HOSTNAME = 'localhost:7001'
+    BACKEND_HOSTNAME = 'localhost:7000'
+
     MLWR_HOST = "localhost"
 
 

--- a/app/download/views.py
+++ b/app/download/views.py
@@ -13,7 +13,7 @@ def download_document(service_id, document_id):
         return jsonify(error='Missing decryption key'), 400
 
     filename = request.args.get('filename')
-    sending_method = request.args.get('sending_method')
+    sending_method = request.args.get('sending_method', "link")
 
     try:
         key = base64_to_bytes(request.args['key'])

--- a/app/download/views.py
+++ b/app/download/views.py
@@ -51,7 +51,7 @@ def download_document_b64(service_id, document_id):
         abort(404)
 
     filename = request.args.get('filename')
-    sending_method = request.args.get('sending_method')
+    sending_method = request.args.get('sending_method', 'link')
 
     try:
         key = base64_to_bytes(request.args['key'])

--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -6,7 +6,7 @@ from app import document_store
 from app.utils import get_mime_type
 from app.utils.mlwr import upload_to_mlwr
 from app.utils.authentication import check_auth
-from app.utils.urls import get_direct_file_url, get_frontend_download_url
+from app.utils.urls import get_direct_file_url, get_api_download_url
 
 upload_blueprint = Blueprint('upload', __name__, url_prefix='')
 upload_blueprint.before_request(check_auth)
@@ -56,7 +56,7 @@ def upload_document(service_id):
                 key=document['encryption_key'],
                 sending_method=sending_method,
             ),
-            'url': get_frontend_download_url(
+            'url': get_api_download_url(
                 service_id=service_id,
                 document_id=document['id'],
                 key=document['encryption_key'],

--- a/app/utils/urls.py
+++ b/app/utils/urls.py
@@ -26,3 +26,20 @@ def get_frontend_download_url(service_id, document_id, key, filename):
     )
 
     return urlunsplit([scheme, netloc, path, query, None])
+
+
+def get_api_download_url(service_id, document_id, key, filename):
+    scheme = current_app.config['HTTP_SCHEME']
+    url = url_for(
+        'download.download_document_b64',
+        service_id=service_id,
+        document_id=document_id,
+        _external=True
+    )
+    url = url.split("://")[-1]
+    query_params = {'key': bytes_to_base64(key), 'filename': filename}
+    query = urlencode(
+        {k: v for k, v in query_params.items() if v},
+        quote_via=quote
+    )
+    return urlunsplit([scheme, url, "", query, None])

--- a/app/utils/urls.py
+++ b/app/utils/urls.py
@@ -30,16 +30,13 @@ def get_frontend_download_url(service_id, document_id, key, filename):
 
 def get_api_download_url(service_id, document_id, key, filename):
     scheme = current_app.config['HTTP_SCHEME']
-    url = url_for(
-        'download.download_document_b64',
-        service_id=service_id,
-        document_id=document_id,
-        _external=True
-    )
-    url = url.split("://")[-1]
+    netloc = current_app.config['BACKEND_HOSTNAME']
+    path = 'd/{}/{}'.format(uuid_to_base64(service_id), uuid_to_base64(document_id))
     query_params = {'key': bytes_to_base64(key), 'filename': filename}
     query = urlencode(
         {k: v for k, v in query_params.items() if v},
         quote_via=quote
     )
-    return urlunsplit([scheme, url, "", query, None])
+
+    return urlunsplit([scheme, netloc, path, query, None])
+

--- a/app/utils/urls.py
+++ b/app/utils/urls.py
@@ -15,19 +15,6 @@ def get_direct_file_url(service_id, document_id, key, sending_method):
     )
 
 
-def get_frontend_download_url(service_id, document_id, key, filename):
-    scheme = current_app.config['HTTP_SCHEME']
-    netloc = current_app.config['FRONTEND_HOSTNAME']
-    path = 'd/{}/{}'.format(uuid_to_base64(service_id), uuid_to_base64(document_id))
-    query_params = {'key': bytes_to_base64(key), 'filename': filename}
-    query = urlencode(
-        {k: v for k, v in query_params.items() if v},
-        quote_via=quote
-    )
-
-    return urlunsplit([scheme, netloc, path, query, None])
-
-
 def get_api_download_url(service_id, document_id, key, filename):
     scheme = current_app.config['HTTP_SCHEME']
     netloc = current_app.config['BACKEND_HOSTNAME']
@@ -39,4 +26,3 @@ def get_api_download_url(service_id, document_id, key, filename):
     )
 
     return urlunsplit([scheme, netloc, path, query, None])
-

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -30,6 +30,7 @@ def test_document_download(client, store, endpoint):
             service_id='00000000-0000-0000-0000-000000000000',
             document_id='ffffffff-ffff-ffff-ffff-ffffffffffff',
             key='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',  # 32 \x00 bytes
+            sending_method="attach"
         )
     )
 
@@ -48,11 +49,15 @@ def test_document_download(client, store, endpoint):
         UUID('00000000-0000-0000-0000-000000000000'),
         UUID('ffffffff-ffff-ffff-ffff-ffffffffffff'),
         bytes(32),
-        None
+        "attach"
     )
 
 
-def test_document_download_with_filename(client, store):
+@pytest.mark.parametrize(
+    "endpoint",
+    ['download.download_document', 'download.download_document_b64'],
+)
+def test_document_download_with_filename(client, store, endpoint):
     store.get.return_value = {
         'body': io.BytesIO(b'PDF document contents'),
         'mimetype': 'application/pdf',
@@ -65,7 +70,8 @@ def test_document_download_with_filename(client, store):
             service_id='00000000-0000-0000-0000-000000000000',
             document_id='ffffffff-ffff-ffff-ffff-ffffffffffff',
             key='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',  # 32 \x00 bytes
-            filename='custom_filename.pdf'
+            filename='custom_filename.pdf',
+            sending_method="attach"
         )
     )
 
@@ -85,7 +91,7 @@ def test_document_download_with_filename(client, store):
         UUID('00000000-0000-0000-0000-000000000000'),
         UUID('ffffffff-ffff-ffff-ffff-ffffffffffff'),
         bytes(32),
-        None
+        "attach"
     )
 
 

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -30,7 +30,6 @@ def test_document_download(client, store, endpoint):
             service_id='00000000-0000-0000-0000-000000000000',
             document_id='ffffffff-ffff-ffff-ffff-ffffffffffff',
             key='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',  # 32 \x00 bytes
-            sending_method="attach"
         )
     )
 
@@ -49,7 +48,7 @@ def test_document_download(client, store, endpoint):
         UUID('00000000-0000-0000-0000-000000000000'),
         UUID('ffffffff-ffff-ffff-ffff-ffffffffffff'),
         bytes(32),
-        "attach"
+        "link"
     )
 
 

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -17,18 +17,18 @@ def antivirus(mocker):
 
 
 @pytest.mark.parametrize(
-    "request_includes_filename, filename, in_frontend_url, expected_filename, sending_method", [
+    "request_includes_filename, filename, in_api_url, expected_filename, sending_method", [
         (True, 'custom_filename.pdf', True, 'custom_filename.pdf', 'attach'),
         (False, 'whatever', False, None, 'link'),
     ]
 )
-def test_document_upload_returns_link_to_frontend(
+def test_document_upload_returns_link_to_api(
     client,
     store,
     antivirus,
     request_includes_filename,
     filename,
-    in_frontend_url,
+    in_api_url,
     expected_filename,
     sending_method,
 ):
@@ -42,7 +42,7 @@ def test_document_upload_returns_link_to_frontend(
         'sending_method': sending_method
     }
 
-    frontend_url_parts = [
+    api_url_parts = [
         'http://localhost:7000',
         '/d/AAAAAAAAAAAAAAAAAAAAAA',
         '/_____________________w',
@@ -54,8 +54,8 @@ def test_document_upload_returns_link_to_frontend(
         data['filename'] = filename
         expected_extension = filename.split('.')[-1]
 
-    if in_frontend_url:
-        frontend_url_parts.append(f'&filename={filename}')
+    if in_api_url:
+        api_url_parts.append(f'&filename={filename}')
 
     response = client.post(
         '/services/00000000-0000-0000-0000-000000000000/documents',
@@ -67,7 +67,7 @@ def test_document_upload_returns_link_to_frontend(
     assert response.json == {
         'document': {
             'id': 'ffffffff-ffff-ffff-ffff-ffffffffffff',
-            'url': ''.join(frontend_url_parts),
+            'url': ''.join(api_url_parts),
             'direct_file_url': ''.join([
                 'http://document-download.test',
                 '/services/00000000-0000-0000-0000-000000000000',

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -43,7 +43,7 @@ def test_document_upload_returns_link_to_frontend(
     }
 
     frontend_url_parts = [
-        'http://localhost:7001',
+        'http://localhost:7000',
         '/d/AAAAAAAAAAAAAAAAAAAAAA',
         '/_____________________w',
         '?key=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'

--- a/tests/utils/test_urls.py
+++ b/tests/utils/test_urls.py
@@ -8,7 +8,7 @@ SAMPLE_KEY = bytes(range(32))
 SAMPLE_B64 = 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8'
 
 
-def test_get_api_download_url_returns_frontend_url_without_filename(app):
+def test_get_api_download_url_returns_url_without_filename(app):
     assert get_api_download_url(
         service_id=UUID(int=0), document_id=UUID(int=1), key=SAMPLE_KEY,
         filename=None
@@ -19,7 +19,7 @@ def test_get_api_download_url_returns_frontend_url_without_filename(app):
     )
 
 
-def test_get_api_download_url_returns_frontend_url_with_filename(app):
+def test_get_api_download_url_returns_url_with_filename(app):
     assert get_api_download_url(
         service_id=UUID(int=0), document_id=UUID(int=1), key=SAMPLE_KEY,
         filename="ça va.pdf"

--- a/tests/utils/test_urls.py
+++ b/tests/utils/test_urls.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from app.utils.urls import get_frontend_download_url, get_direct_file_url
+from app.utils.urls import get_api_download_url, get_frontend_download_url, get_direct_file_url
 
 
 SAMPLE_KEY = bytes(range(32))
@@ -24,6 +24,28 @@ def test_get_frontend_download_url_returns_frontend_url_with_filename(app):
         service_id=UUID(int=0), document_id=UUID(int=1), key=SAMPLE_KEY,
         filename="ça va.pdf"
     ) == 'http://localhost:7001/d/{}/{}?key={}&filename=%C3%A7a%20va.pdf'.format(
+        'AAAAAAAAAAAAAAAAAAAAAA',
+        'AAAAAAAAAAAAAAAAAAAAAQ',
+        SAMPLE_B64
+    )
+
+
+def test_get_api_download_url_returns_frontend_url_without_filename(app):
+    assert get_api_download_url(
+        service_id=UUID(int=0), document_id=UUID(int=1), key=SAMPLE_KEY,
+        filename=None
+    ) == 'http://document-download.test/d/{}/{}?key={}'.format(
+        'AAAAAAAAAAAAAAAAAAAAAA',
+        'AAAAAAAAAAAAAAAAAAAAAQ',
+        SAMPLE_B64
+    )
+
+
+def test_get_api_download_url_returns_frontend_url_with_filename(app):
+    assert get_api_download_url(
+        service_id=UUID(int=0), document_id=UUID(int=1), key=SAMPLE_KEY,
+        filename="ça va.pdf"
+    ) == 'http://document-download.test/d/{}/{}?key={}&filename=%C3%A7a%20va.pdf'.format(
         'AAAAAAAAAAAAAAAAAAAAAA',
         'AAAAAAAAAAAAAAAAAAAAAQ',
         SAMPLE_B64

--- a/tests/utils/test_urls.py
+++ b/tests/utils/test_urls.py
@@ -8,6 +8,17 @@ SAMPLE_KEY = bytes(range(32))
 SAMPLE_B64 = 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8'
 
 
+def test_get_api_download_url_returns_frontend_url_without_filename(app):
+    assert get_api_download_url(
+        service_id=UUID(int=0), document_id=UUID(int=1), key=SAMPLE_KEY,
+        filename=None
+    ) == 'http://localhost:7000/d/{}/{}?key={}'.format(
+        'AAAAAAAAAAAAAAAAAAAAAA',
+        'AAAAAAAAAAAAAAAAAAAAAQ',
+        SAMPLE_B64
+    )
+
+
 def test_get_api_download_url_returns_frontend_url_with_filename(app):
     assert get_api_download_url(
         service_id=UUID(int=0), document_id=UUID(int=1), key=SAMPLE_KEY,

--- a/tests/utils/test_urls.py
+++ b/tests/utils/test_urls.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from app.utils.urls import get_api_download_url, get_frontend_download_url, get_direct_file_url
+from app.utils.urls import get_api_download_url, get_direct_file_url
 
 
 SAMPLE_KEY = bytes(range(32))
@@ -8,44 +8,11 @@ SAMPLE_KEY = bytes(range(32))
 SAMPLE_B64 = 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8'
 
 
-def test_get_frontend_download_url_returns_frontend_url_without_filename(app):
-    assert get_frontend_download_url(
-        service_id=UUID(int=0), document_id=UUID(int=1), key=SAMPLE_KEY,
-        filename=None
-    ) == 'http://localhost:7001/d/{}/{}?key={}'.format(
-        'AAAAAAAAAAAAAAAAAAAAAA',
-        'AAAAAAAAAAAAAAAAAAAAAQ',
-        SAMPLE_B64
-    )
-
-
-def test_get_frontend_download_url_returns_frontend_url_with_filename(app):
-    assert get_frontend_download_url(
-        service_id=UUID(int=0), document_id=UUID(int=1), key=SAMPLE_KEY,
-        filename="ça va.pdf"
-    ) == 'http://localhost:7001/d/{}/{}?key={}&filename=%C3%A7a%20va.pdf'.format(
-        'AAAAAAAAAAAAAAAAAAAAAA',
-        'AAAAAAAAAAAAAAAAAAAAAQ',
-        SAMPLE_B64
-    )
-
-
-def test_get_api_download_url_returns_frontend_url_without_filename(app):
-    assert get_api_download_url(
-        service_id=UUID(int=0), document_id=UUID(int=1), key=SAMPLE_KEY,
-        filename=None
-    ) == 'http://document-download.test/d/{}/{}?key={}'.format(
-        'AAAAAAAAAAAAAAAAAAAAAA',
-        'AAAAAAAAAAAAAAAAAAAAAQ',
-        SAMPLE_B64
-    )
-
-
 def test_get_api_download_url_returns_frontend_url_with_filename(app):
     assert get_api_download_url(
         service_id=UUID(int=0), document_id=UUID(int=1), key=SAMPLE_KEY,
         filename="ça va.pdf"
-    ) == 'http://document-download.test/d/{}/{}?key={}&filename=%C3%A7a%20va.pdf'.format(
+    ) == 'http://localhost:7000/d/{}/{}?key={}&filename=%C3%A7a%20va.pdf'.format(
         'AAAAAAAAAAAAAAAAAAAAAA',
         'AAAAAAAAAAAAAAAAAAAAAQ',
         SAMPLE_B64


### PR DESCRIPTION
# Summary | Résumé

https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/cds-snc/notification-planning/240

This PR sends sets the end user's file link to the new api file link (#65)

**Note**: requires https://github.com/cds-snc/notification-manifests/pull/1182

# Test instructions | Instructions pour tester la modification

- Run api and document-download-api locally
- send yourself files, both attached and as links