### PR TITLE
Allow new file type: application/CDFV2

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -15,6 +15,7 @@ class Config(metaclass=MetaFlaskEnv):
 
     ALLOWED_MIME_TYPES = [
         'application/pdf',
+        'application/CDFV2',
         'text/csv',
         'text/plain',
         'application/msword',  # .doc

--- a/tests/upload/test_views.py
+++ b/tests/upload/test_views.py
@@ -175,7 +175,7 @@ def test_document_upload_unknown_type(client):
 
     assert response.status_code == 400
     assert response.json == {
-        'error': "Unsupported document type 'application/octet-stream'. Supported types are: ['application/pdf', 'text/csv', 'text/plain', 'application/msword', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'image/jpeg', 'image/png', 'application/vnd.ms-excel', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'application/vnd.apple.numbers']" # noqa
+        'error': "Unsupported document type 'application/octet-stream'. Supported types are: ['application/pdf', 'application/CDFV2', 'text/csv', 'text/plain', 'application/msword', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'image/jpeg', 'image/png', 'application/vnd.ms-excel', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'application/vnd.apple.numbers']" # noqa
     }
 
 


### PR DESCRIPTION
# Summary | Résumé

In order to allow GC Forms client's to upload older word docs, allow the mime type `application/CDFV2` which older word docs sometimes get analyzed as being.
