### PR TITLE
Ignore requirements.txt

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>cds-snc/renovate-config"
+  ],
+  "ignorePaths": [
+    "requirements.txt"
   ]
 }


### PR DESCRIPTION
# Summary | Résumé

Ignore requirements.txt as this is the compiled version of our requirements. 

Instead, `make freeze-requirements` needs to be run after renovate updates our other requirements files.