### PR TITLE
Fix sending large files locally

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -43,7 +43,7 @@ jobs:
         cp -f .env.example .env
 
     - name: Checks for new endpoints against AWS WAF rules
-      uses: cds-snc/notification-utils/.github/actions/waffles@main
+      uses: cds-snc/notification-utils/.github/actions/waffles@49.1.0
       with:
         app-loc: '/github/workspace'
         app-libs: '/github/workspace/env/site-packages'

--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -14,10 +14,11 @@ upload_blueprint.before_request(check_auth)
 
 @upload_blueprint.route('/services/<uuid:service_id>/documents', methods=['POST'])
 def upload_document(service_id):
-    if 'document' not in request.files:
+    try:
+        mimetype = get_mime_type(request.files['document'])
+    except:
         return jsonify(error='No document upload'), 400
 
-    mimetype = get_mime_type(request.files['document'])
     if not mime_type_is_allowed(mimetype, service_id):
         return jsonify(
             error="Unsupported document type '{}'. Supported types are: {}".format(


### PR DESCRIPTION
# Summary | Résumé

The API was hanging on the first `if` statement for some reason when sending file attachments over 10kb. I changed the `if` to a try/except and now I can send big files.

# Test instructions | Instructions pour tester la modification

Run locally along with notification-api and verify that sending attachments over 100kb in size works.