### PR TITLE
Add a timeout for scan-files

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -23,7 +23,7 @@ download_blueprint = Blueprint("download", __name__, url_prefix="")
 
 MALICIOUS_CONTENT_ERROR_CODE = 423
 SCAN_IN_PROGRESS_ERROR_CODE = 428
-ALLOWED_SCAN_TIME = timedelta(minutes=5)
+SCAN_TIMEOUT = timedelta(minutes=5)
 
 
 @download_blueprint.route("/services/<uuid:service_id>/documents/<uuid:document_id>", methods=["GET"])
@@ -125,7 +125,7 @@ def check_scan_verdict(service_id, document_id):
         return jsonify(error=str(e)), MALICIOUS_CONTENT_ERROR_CODE
     except ScanInProgressError as e:
         age = scan_files_document_store.get_object_age(service_id, document_id, sending_method)
-        if age > ALLOWED_SCAN_TIME:
+        if age > SCAN_TIMEOUT:
             return jsonify(scan_verdict="scan_timed_out"), 200
 
         current_app.logger.info(

--- a/app/download/views.py
+++ b/app/download/views.py
@@ -23,7 +23,7 @@ download_blueprint = Blueprint("download", __name__, url_prefix="")
 
 MALICIOUS_CONTENT_ERROR_CODE = 423
 SCAN_IN_PROGRESS_ERROR_CODE = 428
-SCAN_TIMEOUT = timedelta(minutes=5)
+SCAN_TIMEOUT_SECONDS = 5 * 60
 
 
 @download_blueprint.route("/services/<uuid:service_id>/documents/<uuid:document_id>", methods=["GET"])
@@ -124,8 +124,8 @@ def check_scan_verdict(service_id, document_id):
         )
         return jsonify(error=str(e)), MALICIOUS_CONTENT_ERROR_CODE
     except ScanInProgressError as e:
-        age = scan_files_document_store.get_object_age(service_id, document_id, sending_method)
-        if age > SCAN_TIMEOUT:
+        age_seconds = scan_files_document_store.get_object_age(service_id, document_id, sending_method)
+        if age_seconds > SCAN_TIMEOUT_SECONDS:
             return jsonify(scan_verdict="scan_timed_out"), 200
 
         current_app.logger.info(

--- a/app/download/views.py
+++ b/app/download/views.py
@@ -21,7 +21,7 @@ download_blueprint = Blueprint("download", __name__, url_prefix="")
 
 MALICIOUS_CONTENT_ERROR_CODE = 423
 SCAN_IN_PROGRESS_ERROR_CODE = 428
-SCAN_TIMEOUT_SECONDS = 5 * 60
+SCAN_TIMEOUT_SECONDS = 10 * 60
 
 
 @download_blueprint.route("/services/<uuid:service_id>/documents/<uuid:document_id>", methods=["GET"])

--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -130,8 +130,8 @@ class ScanFilesDocumentStore:
             raise ScanInProgressError("Content scanning is in progress")
         return av_status
 
-    def get_object_age(self, service_id, document_id, sending_method) -> int:
-        """ 
+    def get_object_age_seconds(self, service_id, document_id, sending_method) -> int:
+        """
         Returns the object age in seconds.
         """
 
@@ -145,7 +145,7 @@ class ScanFilesDocumentStore:
             last_modified = response["ResponseMetadata"]["HTTPHeaders"]["last-modified"]
             last_modified_parsed = datetime.strptime(last_modified, "%a, %d %b %Y %H:%M:%S %Z")
             age = datetime.now() - last_modified_parsed
-            
+
             return age.seconds
 
         except BotoClientError as e:

--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -1,6 +1,6 @@
 import os
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import boto3
 from botocore.exceptions import ClientError as BotoClientError
@@ -130,8 +130,10 @@ class ScanFilesDocumentStore:
             raise ScanInProgressError("Content scanning is in progress")
         return av_status
 
-    def get_object_age(self, service_id, document_id, sending_method) -> timedelta:
-        """ """
+    def get_object_age(self, service_id, document_id, sending_method) -> int:
+        """ 
+        Returns the object age in seconds.
+        """
 
         try:
             # ETag doesn't matter, but I need to specify ObjectAttributes
@@ -143,7 +145,8 @@ class ScanFilesDocumentStore:
             last_modified = response["ResponseMetadata"]["HTTPHeaders"]["last-modified"]
             last_modified_parsed = datetime.strptime(last_modified, "%a, %d %b %Y %H:%M:%S %Z")
             age = datetime.now() - last_modified_parsed
-            return age
+            
+            return age.seconds
 
         except BotoClientError as e:
             raise DocumentStoreError(e.response["Error"])

--- a/poetry.lock
+++ b/poetry.lock
@@ -501,6 +501,21 @@ dev = ["coverage", "pre-commit", "pytest", "pytest-mock"]
 tests = ["coverage", "pytest", "pytest-mock"]
 
 [[package]]
+name = "freezegun"
+version = "1.2.2"
+description = "Let your Python tests travel through time"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "freezegun-1.2.2-py3-none-any.whl", hash = "sha256:ea1b963b993cb9ea195adbd893a48d573fda951b0da64f60883d7e988b606c9f"},
+    {file = "freezegun-1.2.2.tar.gz", hash = "sha256:cd22d1ba06941384410cd967d8a99d5ae2442f57dfafeff2fda5de8dc5c05446"},
+]
+
+[package.dependencies]
+python-dateutil = ">=2.7"
+
+[[package]]
 name = "gevent"
 version = "22.10.2"
 description = "Coroutine-based network library"
@@ -1550,5 +1565,5 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.10"
-content-hash = "120ef0bac6afba3acbf267769fc4e39ff8b28a70c49ecd999ff9de4353b4cf5d"
+python-versions = "~3.10"
+content-hash = "501981f2a925c4a7416fe32d7172e4483a0a9bba6d3c1f9b53ae2f3ec1ddad9a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ pycryptodome = "*"
 [tool.poetry.group.test.dependencies]
 black = "22.12.0"
 flake8 = "3.9.2"
+freezegun = "1.2.2"
 
 pytest = "7.2.0"
 pytest-env = "0.8.1"

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -157,6 +157,7 @@ def test_document_download_document_store_error(client, store):
 )
 def test_content_scan_errors(client, scan_files_store, response_code, error):
     scan_files_store.check_scan_verdict.side_effect = error
+    scan_files_store.get_object_age_seconds.return_value = 30
     response = client.post(
         url_for(
             "download.check_scan_verdict",

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -185,7 +185,7 @@ def test_content_scan_no_error(client, scan_files_store):
 
 def test_scan_times_out(client, scan_files_store):
     scan_files_store.check_scan_verdict.side_effect = ScanInProgressError()
-    scan_files_store.get_object_age_seconds.return_value = 6 * 60
+    scan_files_store.get_object_age_seconds.return_value = 15 * 60
     response = client.post(
         url_for(
             "download.check_scan_verdict",

--- a/tests/utils/test_store.py
+++ b/tests/utils/test_store.py
@@ -170,16 +170,10 @@ def test_get_document_flagged_malicious(scan_files_store):
 
 
 @freeze_time("2023-02-17 16:00:00.000000")
-def test_get_object_age(scan_files_store):
+def test_get_object_age_seconds(scan_files_store):
     scan_files_store.s3.get_object_attributes = mock.Mock(
-        return_value={
-            "ResponseMetadata": {
-                "HTTPHeaders": {
-                    "last-modified": "Fri, 17 Feb 2023 15:05:00 GMT"
-                }
-            }
-        }
+        return_value={"ResponseMetadata": {"HTTPHeaders": {"last-modified": "Fri, 17 Feb 2023 15:05:00 GMT"}}}
     )
-    age_seconds = scan_files_store.get_object_age("service-id", "document-id", sending_method="link")
+    age_seconds = scan_files_store.get_object_age_seconds("service-id", "document-id", sending_method="link")
     expected_seconds = timedelta(minutes=55).seconds
     assert age_seconds == expected_seconds

--- a/tests/utils/test_store.py
+++ b/tests/utils/test_store.py
@@ -1,6 +1,8 @@
 import uuid
 from unittest import mock
+from datetime import timedelta
 
+from freezegun import freeze_time
 import pytest
 from botocore.exceptions import ClientError as BotoClientError
 
@@ -165,3 +167,19 @@ def test_get_document_flagged_malicious(scan_files_store):
     )
     with pytest.raises(MaliciousContentError):
         scan_files_store.check_scan_verdict("service-id", "document-id", sending_method="link")
+
+
+@freeze_time("2023-02-17 16:00:00.000000")
+def test_get_object_age(scan_files_store):
+    scan_files_store.s3.get_object_attributes = mock.Mock(
+        return_value={
+            "ResponseMetadata": {
+                "HTTPHeaders": {
+                    "last-modified": "Fri, 17 Feb 2023 15:05:00 GMT"
+                }
+            }
+        }
+    )
+    age_seconds = scan_files_store.get_object_age("service-id", "document-id", sending_method="link")
+    expected_seconds = timedelta(minutes=55).seconds
+    assert age_seconds == expected_seconds


### PR DESCRIPTION
# Summary | Résumé

This PR adds a timeout for the virus scan. This will protect Notify so it can continue to send in the event that scan-files goes down or is taking a really long time. If the virus scan has not completed by `SCAN_TIMEOUT_SECONDS` (currently set to 10 minutes) after the file object was created in S3, then return a 200 code along with the status `scan_timed_out` so the email attachment can be sent anyway. 

Here is the [updated decision tree diagram](https://github.com/cds-snc/notification-adr/blob/feat/malicious-content-scanning/records/2023-01-24.malicious-content-scanning.md#duplicate-s3-bucket) covering this logic.

# Test instructions | Instructions pour tester la modification

I can't think of a way to test this without either a) taking scan-files down, or b) modifying the code in this PR to return an in-progress. So here are the instructions for b):
1. check out this branch
2. add the following code to app/utils/store.py line 112: `raise ScanInProgressError("Content scanning is in progress")
`. This will simulate a scan that either never starts or does not complete
3. Change the timeout to 2 minutes so you don't have to wait so long
4. run with `make run`
5. set notification-api to point to your local dd-api, with `DOCUMENT_DOWNLOAD_API_HOST=http://host.docker.internal:7000`, and run locally
6. send an email w/ an attachment via your local API.
7. The email should not send for the first 2 minutes (the timeout duration), and then it should be sent successfully at some point after 2 minutes elapses.
8. verify that you see the dd-api log: `Scan timed out for document: ...` 