### PR TITLE
Add 408 response code when the scan times out

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -21,7 +21,8 @@ download_blueprint = Blueprint("download", __name__, url_prefix="")
 
 MALICIOUS_CONTENT_ERROR_CODE = 423
 SCAN_IN_PROGRESS_ERROR_CODE = 428
-SCAN_TIMEOUT_SECONDS = 10 * 60
+SCAN_TIMEOUT_ERROR_CODE = 408
+SCAN_TIMEOUT_SECONDS = 11 * 60
 
 
 @download_blueprint.route("/services/<uuid:service_id>/documents/<uuid:document_id>", methods=["GET"])
@@ -132,7 +133,7 @@ def check_scan_verdict(service_id, document_id):
                     "document_id": document_id,
                 },
             )
-            return jsonify(scan_verdict="scan_timed_out"), 200
+            return jsonify(scan_verdict="scan_timed_out"), SCAN_TIMEOUT_ERROR_CODE
 
         current_app.logger.info(
             "Scan in progress, refused to download document: {}".format(e),

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -193,5 +193,5 @@ def test_scan_times_out(client, scan_files_store):
             document_id="ffffffff-ffff-ffff-ffff-ffffffffffff",
         )
     )
-    assert response.status_code == 200
+    assert response.status_code == 408
     assert json.loads(response.data) == {"scan_verdict": "scan_timed_out"}


### PR DESCRIPTION
# Summary | Résumé

This PR does the following:
- Add 408 response code when the scan times out
- increase the timeout to 11 minutes so that celery will retry at least 2 times
