### PR TITLE
Task/add exceptions

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -49,6 +49,19 @@ def download_document(service_id, document_id):
         )
         return jsonify(error=str(e)), MALICIOUS_CONTENT_ERROR_CODE
     except ScanInProgressError as e:
+        age_seconds = scan_files_document_store.get_object_age_seconds(
+            service_id, document_id, sending_method
+        )
+        if age_seconds > SCAN_TIMEOUT_SECONDS:
+            current_app.logger.info(
+                "Scan timed out for document: {}".format(e),
+                extra={
+                    "service_id": service_id,
+                    "document_id": document_id,
+                },
+            )
+            return jsonify(scan_verdict="scan_timed_out"), 200
+
         current_app.logger.info(
             "Scan in progress, refused to download document: {}".format(e),
             extra={
@@ -119,6 +132,19 @@ def download_document_b64(service_id, document_id):
         )
         return jsonify(error=str(e)), MALICIOUS_CONTENT_ERROR_CODE
     except ScanInProgressError as e:
+        age_seconds = scan_files_document_store.get_object_age_seconds(
+            service_id, document_id, sending_method
+        )
+        if age_seconds > SCAN_TIMEOUT_SECONDS:
+            current_app.logger.info(
+                "Scan timed out for document: {}".format(e),
+                extra={
+                    "service_id": service_id,
+                    "document_id": document_id,
+                },
+            )
+            return jsonify(scan_verdict="scan_timed_out"), 200
+
         current_app.logger.info(
             "Scan in progress, refused to download document: {}".format(e),
             extra={

--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -96,7 +96,6 @@ class ScanFilesDocumentStore:
         print(f"self.bucket: {self.bucket}")
 
     def put(self, service_id, document_id, document_stream, sending_method, mimetype="application/pdf"):
-
         self.s3.put_object(
             Bucket=self.bucket,
             Key=self.get_document_key(service_id, document_id, sending_method),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,6 @@ def app():
 
 @pytest.fixture()
 def client(app):
-
     with app.test_client() as client:
         yield client
 

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -151,26 +151,25 @@ def test_document_download_document_store_error(client, store, mocker):
 
 
 @pytest.mark.parametrize(
-    "endpoint, response_code, error",
+    "endpoint, response_code, error, scan_return",
     [
-        ["download.download_document", 428, ScanInProgressError()],
-        ["download.download_document", 423, MaliciousContentError()],
-        ["download.download_document", 423, SuspiciousContentError()],
-        ["download.download_document", 404, DocumentStoreError()],
-        ["download.download_document_b64", 428, ScanInProgressError()],
-        ["download.download_document_b64", 423, MaliciousContentError()],
-        ["download.download_document_b64", 423, SuspiciousContentError()],
-        ["download.download_document_b64", 404, DocumentStoreError()],
+        ["download.download_document", 200, ScanInProgressError(), 900],
+        ["download.download_document", 428, ScanInProgressError(), 30],
+        ["download.download_document", 423, MaliciousContentError(), 300],
+        ["download.download_document", 423, SuspiciousContentError(), 300],
+        ["download.download_document", 404, DocumentStoreError(), 300],
+        ["download.download_document_b64", 200, ScanInProgressError(), 900],
+        ["download.download_document_b64", 428, ScanInProgressError(), 30],
+        ["download.download_document_b64", 423, MaliciousContentError(), 300],
+        ["download.download_document_b64", 423, SuspiciousContentError(), 300],
+        ["download.download_document_b64", 404, DocumentStoreError(), 300],
     ],
 )
-def test_document_download_check_scan_verdict_errors(client, store, mocker, endpoint, response_code, error):
+def test_document_download_check_scan_verdict_errors(
+    client, scan_files_store, mocker, endpoint, response_code, error, scan_return
+):
     mocker.patch("app.download.views.check_scan_verdict", side_effect=error)
-    store.get.return_value = {
-        "body": io.BytesIO(b"PDF document contents"),
-        "mimetype": "application/pdf",
-        "size": 100,
-    }
-
+    scan_files_store.get_object_age_seconds.return_value = scan_return
     response = client.get(
         url_for(
             endpoint,


### PR DESCRIPTION
# Summary | Résumé

We wanted to add exceptions to the document_download api for when we call check_scan_verdict and document_downland_b64 within the main document_download api call.