### PR TITLE
Add exception handling for files

### DIFF
--- a/app/download/views.py
+++ b/app/download/views.py
@@ -130,29 +130,11 @@ def download_document_b64(service_id, document_id):
                 "document_id": document_id,
             },
         )
-        return jsonify(error=str(e)), MALICIOUS_CONTENT_ERROR_CODE
+        abort(404)
     except ScanInProgressError as e:
-        age_seconds = scan_files_document_store.get_object_age_seconds(
-            service_id, document_id, sending_method
-        )
-        if age_seconds > SCAN_TIMEOUT_SECONDS:
-            current_app.logger.info(
-                "Scan timed out for document: {}".format(e),
-                extra={
-                    "service_id": service_id,
-                    "document_id": document_id,
-                },
-            )
-            return jsonify(scan_verdict="scan_timed_out"), 200
-
-        current_app.logger.info(
-            "Scan in progress, refused to download document: {}".format(e),
-            extra={
-                "service_id": service_id,
-                "document_id": document_id,
-            },
-        )
-        return jsonify(error=str(e)), SCAN_IN_PROGRESS_ERROR_CODE
+    # at this point the email with the "link" type attachment has been sent
+    # return the document to the user in case the scan timed out
+    continue
     except DocumentStoreError as e:
         current_app.logger.info(
             "Failed to get tags from document: {}".format(e),

--- a/app/download/views.py
+++ b/app/download/views.py
@@ -132,9 +132,10 @@ def download_document_b64(service_id, document_id):
         )
         abort(404)
     except ScanInProgressError as e:
-    # at this point the email with the "link" type attachment has been sent
-    # return the document to the user in case the scan timed out
-    continue
+        # at this point the email with the "link" type attachment has been sent
+        # return the document to the user in case the scan timed out
+        current_app.logger.info("Scan is in progress but we will return the link, error is: {}".format(e))
+        pass
     except DocumentStoreError as e:
         current_app.logger.info(
             "Failed to get tags from document: {}".format(e),

--- a/app/download/views.py
+++ b/app/download/views.py
@@ -49,27 +49,9 @@ def download_document(service_id, document_id):
         )
         return jsonify(error=str(e)), MALICIOUS_CONTENT_ERROR_CODE
     except ScanInProgressError as e:
-        age_seconds = scan_files_document_store.get_object_age_seconds(
-            service_id, document_id, sending_method
-        )
-        if age_seconds > SCAN_TIMEOUT_SECONDS:
-            current_app.logger.info(
-                "Scan timed out for document: {}".format(e),
-                extra={
-                    "service_id": service_id,
-                    "document_id": document_id,
-                },
-            )
-            return jsonify(scan_verdict="scan_timed_out"), 200
-
-        current_app.logger.info(
-            "Scan in progress, refused to download document: {}".format(e),
-            extra={
-                "service_id": service_id,
-                "document_id": document_id,
-            },
-        )
-        return jsonify(error=str(e)), SCAN_IN_PROGRESS_ERROR_CODE
+        # return the document to the user in case the scan timed out
+        current_app.logger.info("Scan is in progress but we will return the link, error is: {}".format(e))
+        pass
     except DocumentStoreError as e:
         current_app.logger.info(
             "Failed to get tags from document: {}".format(e),

--- a/app/download/views.py
+++ b/app/download/views.py
@@ -38,6 +38,49 @@ def download_document(service_id, document_id):
         return jsonify(error="Invalid decryption key"), 400
 
     try:
+        check_scan_verdict(service_id, document_id, sending_method)
+    except (MaliciousContentError, SuspiciousContentError) as e:
+        current_app.logger.info(
+            "Malicious content detected, refused to download document: {}".format(e),
+            extra={
+                "service_id": service_id,
+                "document_id": document_id,
+            },
+        )
+        return jsonify(error=str(e)), MALICIOUS_CONTENT_ERROR_CODE
+    except ScanInProgressError as e:
+        age_seconds = scan_files_document_store.get_object_age_seconds(
+            service_id, document_id, sending_method
+        )
+        if age_seconds > SCAN_TIMEOUT_SECONDS:
+            current_app.logger.info(
+                "Scan timed out for document: {}".format(e),
+                extra={
+                    "service_id": service_id,
+                    "document_id": document_id,
+                },
+            )
+            return jsonify(scan_verdict="scan_timed_out"), 200
+
+        current_app.logger.info(
+            "Scan in progress, refused to download document: {}".format(e),
+            extra={
+                "service_id": service_id,
+                "document_id": document_id,
+            },
+        )
+        return jsonify(error=str(e)), SCAN_IN_PROGRESS_ERROR_CODE
+    except DocumentStoreError as e:
+        current_app.logger.info(
+            "Failed to get tags from document: {}".format(e),
+            extra={
+                "service_id": service_id,
+                "document_id": document_id,
+            },
+        )
+        abort(404)
+
+    try:
         document = document_store.get(service_id, document_id, key, sending_method)
     except DocumentStoreError as e:
         current_app.logger.info(
@@ -78,6 +121,49 @@ def download_document_b64(service_id, document_id):
         abort(404)
 
     try:
+        check_scan_verdict(service_id, document_id, sending_method)
+    except (MaliciousContentError, SuspiciousContentError) as e:
+        current_app.logger.info(
+            "Malicious content detected, refused to download document: {}".format(e),
+            extra={
+                "service_id": service_id,
+                "document_id": document_id,
+            },
+        )
+        return jsonify(error=str(e)), MALICIOUS_CONTENT_ERROR_CODE
+    except ScanInProgressError as e:
+        age_seconds = scan_files_document_store.get_object_age_seconds(
+            service_id, document_id, sending_method
+        )
+        if age_seconds > SCAN_TIMEOUT_SECONDS:
+            current_app.logger.info(
+                "Scan timed out for document: {}".format(e),
+                extra={
+                    "service_id": service_id,
+                    "document_id": document_id,
+                },
+            )
+            return jsonify(scan_verdict="scan_timed_out"), 200
+
+        current_app.logger.info(
+            "Scan in progress, refused to download document: {}".format(e),
+            extra={
+                "service_id": service_id,
+                "document_id": document_id,
+            },
+        )
+        return jsonify(error=str(e)), SCAN_IN_PROGRESS_ERROR_CODE
+    except DocumentStoreError as e:
+        current_app.logger.info(
+            "Failed to get tags from document: {}".format(e),
+            extra={
+                "service_id": service_id,
+                "document_id": document_id,
+            },
+        )
+        abort(404)
+
+    try:
         document = document_store.get(service_id, document_id, key, sending_method)
     except DocumentStoreError as e:
         current_app.logger.info(
@@ -107,8 +193,8 @@ def download_document_b64(service_id, document_id):
 @download_blueprint.route(
     "/services/<uuid:service_id>/documents/<uuid:document_id>/scan-verdict", methods=["POST"]
 )
-def check_scan_verdict(service_id, document_id):
-    sending_method = request.form.get("sending_method")
+def check_scan_verdict(service_id, document_id, sending_method=None):
+    sending_method = request.form.get("sending_method", sending_method)
     try:
         av_status = scan_files_document_store.check_scan_verdict(service_id, document_id, sending_method)
     except (MaliciousContentError, SuspiciousContentError) as e:

--- a/app/utils/store.py
+++ b/app/utils/store.py
@@ -96,7 +96,6 @@ class ScanFilesDocumentStore:
         print(f"self.bucket: {self.bucket}")
 
     def put(self, service_id, document_id, document_stream, sending_method, mimetype="application/pdf"):
-
         self.s3.put_object(
             Bucket=self.bucket,
             Key=self.get_document_key(service_id, document_id, sending_method),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,6 @@ def app():
 
 @pytest.fixture()
 def client(app):
-
     with app.test_client() as client:
         yield client
 

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -159,17 +159,22 @@ def test_document_download_document_store_error(client, store, mocker):
         ["download.download_document", 423, SuspiciousContentError(), 300],
         ["download.download_document", 404, DocumentStoreError(), 300],
         ["download.download_document_b64", 200, ScanInProgressError(), 900],
-        ["download.download_document_b64", 428, ScanInProgressError(), 30],
-        ["download.download_document_b64", 423, MaliciousContentError(), 300],
-        ["download.download_document_b64", 423, SuspiciousContentError(), 300],
+        ["download.download_document_b64", 200, ScanInProgressError(), 30],
+        ["download.download_document_b64", 404, MaliciousContentError(), 300],
+        ["download.download_document_b64", 404, SuspiciousContentError(), 300],
         ["download.download_document_b64", 404, DocumentStoreError(), 300],
     ],
 )
 def test_document_download_check_scan_verdict_errors(
-    client, scan_files_store, mocker, endpoint, response_code, error, scan_return
+    client, store, scan_files_store, mocker, endpoint, response_code, error, scan_return
 ):
     mocker.patch("app.download.views.check_scan_verdict", side_effect=error)
     scan_files_store.get_object_age_seconds.return_value = scan_return
+    store.get.return_value = store.get.return_value = {
+        "body": io.BytesIO(b"PDF document contents"),
+        "mimetype": "application/pdf",
+        "size": 100,
+    }
     response = client.get(
         url_for(
             endpoint,

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -154,7 +154,7 @@ def test_document_download_document_store_error(client, store, mocker):
     "endpoint, response_code, error, scan_return",
     [
         ["download.download_document", 200, ScanInProgressError(), 900],
-        ["download.download_document", 428, ScanInProgressError(), 30],
+        ["download.download_document", 200, ScanInProgressError(), 30],
         ["download.download_document", 423, MaliciousContentError(), 300],
         ["download.download_document", 423, SuspiciousContentError(), 300],
         ["download.download_document", 404, DocumentStoreError(), 300],

--- a/tests/download/test_views.py
+++ b/tests/download/test_views.py
@@ -28,7 +28,8 @@ def scan_files_store(mocker):
     "endpoint",
     ["download.download_document", "download.download_document_b64"],
 )
-def test_document_download(client, store, endpoint):
+def test_document_download(client, store, endpoint, mocker):
+    mocker.patch("app.download.views.check_scan_verdict", return_value=None)
     store.get.return_value = {
         "body": io.BytesIO(b"PDF document contents"),
         "mimetype": "application/pdf",
@@ -67,7 +68,8 @@ def test_document_download(client, store, endpoint):
     "endpoint",
     ["download.download_document", "download.download_document_b64"],
 )
-def test_document_download_with_filename(client, store, endpoint):
+def test_document_download_with_filename(client, store, endpoint, mocker):
+    mocker.patch("app.download.views.check_scan_verdict", return_value=None)
     store.get.return_value = {
         "body": io.BytesIO(b"PDF document contents"),
         "mimetype": "application/pdf",
@@ -132,7 +134,8 @@ def test_document_download_with_invalid_decryption_key(client):
     assert response.json == {"error": "Invalid decryption key"}
 
 
-def test_document_download_document_store_error(client, store):
+def test_document_download_document_store_error(client, store, mocker):
+    mocker.patch("app.download.views.check_scan_verdict", return_value=None)
     store.get.side_effect = DocumentStoreError("something went wrong")
     response = client.get(
         url_for(
@@ -145,6 +148,37 @@ def test_document_download_document_store_error(client, store):
 
     assert response.status_code == 400
     assert response.json == {"error": "something went wrong"}
+
+
+@pytest.mark.parametrize(
+    "endpoint, response_code, error, scan_return",
+    [
+        ["download.download_document", 200, ScanInProgressError(), 900],
+        ["download.download_document", 428, ScanInProgressError(), 30],
+        ["download.download_document", 423, MaliciousContentError(), 300],
+        ["download.download_document", 423, SuspiciousContentError(), 300],
+        ["download.download_document", 404, DocumentStoreError(), 300],
+        ["download.download_document_b64", 200, ScanInProgressError(), 900],
+        ["download.download_document_b64", 428, ScanInProgressError(), 30],
+        ["download.download_document_b64", 423, MaliciousContentError(), 300],
+        ["download.download_document_b64", 423, SuspiciousContentError(), 300],
+        ["download.download_document_b64", 404, DocumentStoreError(), 300],
+    ],
+)
+def test_document_download_check_scan_verdict_errors(
+    client, scan_files_store, mocker, endpoint, response_code, error, scan_return
+):
+    mocker.patch("app.download.views.check_scan_verdict", side_effect=error)
+    scan_files_store.get_object_age_seconds.return_value = scan_return
+    response = client.get(
+        url_for(
+            endpoint,
+            service_id="00000000-0000-0000-0000-000000000000",
+            document_id="ffffffff-ffff-ffff-ffff-ffffffffffff",
+            key="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",  # 32 \x00 bytes
+        )
+    )
+    assert response.status_code == response_code
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Summary | Résumé

Tested this locally:
1. Added exception handling for files
2. Needed a sending method for check_scan_verdict
<img width="1108" alt="Screenshot 2023-02-22 at 3 39 19 PM" src="https://user-images.githubusercontent.com/8869623/220754074-89e97aa5-7269-424d-b89e-103ee1181ad5.png">
<img width="602" alt="Screenshot 2023-02-22 at 3 39 12 PM" src="https://user-images.githubusercontent.com/8869623/220754078-7de72591-b334-457b-bfd6-16071240cf3a.png">


