### PR TITLE
switch auth to OIDC

### DIFF
--- a/.github/workflows/docker-vulnerability-scan.yml
+++ b/.github/workflows/docker-vulnerability-scan.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Configure credentials to CDS public ECR using OIDC
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
         with:
           role-to-assume: arn:aws:iam::283582579564:role/notification-document-download-api-apply
           role-session-name: NotifyDocumentDownloadApiGitHubActions

--- a/.github/workflows/docker-vulnerability-scan.yml
+++ b/.github/workflows/docker-vulnerability-scan.yml
@@ -8,6 +8,10 @@ on:
 env:
   DOCKER_SLUG: public.ecr.aws/cds-snc/notify-document-download-api
 
+permissions:
+  id-token: write   # This is required for requesting the OIDC JWT
+  contents: read    # This is required for actions/checkout
+
 jobs:
   docker-vulnerability-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-vulnerability-scan.yml
+++ b/.github/workflows/docker-vulnerability-scan.yml
@@ -13,13 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Configure AWS credentials
-        id: aws-creds
-        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
+      - name: Configure credentials to CDS public ECR using OIDC
+        uses: aws-actions/configure-aws-credentials@master
         with:
-          aws-access-key-id: ${{ secrets.AWS_ECR_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::283582579564:role/notification-document-download-api-apply
+          role-session-name: NotifyDocumentDownloadApiGitHubActions
+          aws-region: "us-east-1"
 
       - name: Login to ECR
         id: login-ecr

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -29,20 +29,24 @@ jobs:
         sudo mv ./kubectl /usr/local/bin/kubectl
         kubectl version --client
         mkdir -p $HOME/.kube
-    - name: AWS auth with ECR
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ECR_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ECR_SECRET_ACCESS_KEY }}
-      run: |
-        aws ecr-public get-login-password --region us-east-1 > /tmp/aws
-        cat /tmp/aws | docker login --username AWS --password-stdin $DOCKER_ORG
-        rm /tmp/aws
+
+    - name: Configure credentials to CDS public ECR using OIDC
+      uses: aws-actions/configure-aws-credentials@master
+      with:
+        role-to-assume: arn:aws:iam::283582579564:role/notification-document-download-api-apply
+        role-session-name: SREBotGitHubActions
+        aws-region: "ca-central-1"
+    - name: Login to ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@261a7de32bda11ba01f4d75c4ed6caf3739e54be # v1.5.3
+
     - name: Build
       run: |
         docker build --build-arg GIT_SHA=${GITHUB_SHA::7} -t $DOCKER_SLUG:${GITHUB_SHA::7} -t $DOCKER_SLUG:latest -f ci/Dockerfile .
     - name: Publish
       run: |
         docker push $DOCKER_SLUG:latest && docker push $DOCKER_SLUG:${GITHUB_SHA::7}
+
     - name: Get Kubernetes configuration
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -35,7 +35,7 @@ jobs:
         mkdir -p $HOME/.kube
 
     - name: Configure credentials to CDS public ECR using OIDC
-      uses: aws-actions/configure-aws-credentials@master
+      uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
       with:
         role-to-assume: arn:aws:iam::283582579564:role/notification-document-download-api-apply
         role-session-name: NotifyDocumentDownloadApiGitHubActions
@@ -54,7 +54,7 @@ jobs:
         docker push $DOCKER_SLUG:latest && docker push $DOCKER_SLUG:${GITHUB_SHA::7}
 
     - name: Configure credentials to Notify account using OIDC
-      uses: aws-actions/configure-aws-credentials@master
+      uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
       with:
         role-to-assume: arn:aws:iam::239043911459:role/notification-document-download-api-apply
         role-session-name: NotifyDocumentDownloadApiGitHubActions

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -10,6 +10,10 @@ env:
   DOCKER_SLUG: public.ecr.aws/cds-snc/notify-document-download-api
   KUBECTL_VERSION: '1.18.0'
 
+permissions:
+  id-token: write   # This is required for requesting the OIDC JWT
+  contents: read    # This is required for actions/checkout
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -34,11 +38,13 @@ jobs:
       uses: aws-actions/configure-aws-credentials@master
       with:
         role-to-assume: arn:aws:iam::283582579564:role/notification-document-download-api-apply
-        role-session-name: SREBotGitHubActions
-        aws-region: "ca-central-1"
+        role-session-name: NotifyDocumentDownloadApiGitHubActions
+        aws-region: "us-east-1"
     - name: Login to ECR
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@261a7de32bda11ba01f4d75c4ed6caf3739e54be # v1.5.3
+      with:
+        registry-type: public
 
     - name: Build
       run: |
@@ -47,16 +53,17 @@ jobs:
       run: |
         docker push $DOCKER_SLUG:latest && docker push $DOCKER_SLUG:${GITHUB_SHA::7}
 
+    - name: Configure credentials to Notify account using OIDC
+      uses: aws-actions/configure-aws-credentials@master
+      with:
+        role-to-assume: arn:aws:iam::239043911459:role/notification-document-download-api-apply
+        role-session-name: NotifyDocumentDownloadApiGitHubActions
+        aws-region: "ca-central-1"
+
     - name: Get Kubernetes configuration
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       run: |
         aws eks --region $AWS_REGION update-kubeconfig --name notification-canada-ca-staging-eks-cluster --kubeconfig $HOME/.kube/config
     - name: Update image in staging
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       run: |
         kubectl set image deployment.apps/document-download-api document-download-api=$DOCKER_SLUG:${GITHUB_SHA::7} -n=notification-canada-ca --kubeconfig=$HOME/.kube/config
 


### PR DESCRIPTION
# Summary | Résumé

Switch auth to CDS' public ECR from IAM user to OIDC.
One less key to rotate next time 🎉

Copy paste from what's working in admin, essentially.

Also change `docker-vulnerability-scan.yml` which was also using the ECR IAM user.

# Test instructions | Instructions pour tester la modification

After this merges to main we should make sure that the new admin image gets uploaded to https://gallery.ecr.aws/cds-snc/notify-document-download-api
