### PR TITLE
fix: docker-scan workflow permissions

### DIFF
--- a/.github/workflows/docker-vulnerability-scan.yml
+++ b/.github/workflows/docker-vulnerability-scan.yml
@@ -9,8 +9,9 @@ env:
   DOCKER_SLUG: public.ecr.aws/cds-snc/notify-document-download-api
 
 permissions:
-  id-token: write   # This is required for requesting the OIDC JWT
-  contents: read    # This is required for actions/checkout
+  id-token: write        # This is required for requesting the OIDC JWT
+  contents: read         # This is required for actions/checkout
+  security-events: write # This is required for the docker-scan action
 
 jobs:
   docker-vulnerability-scan:


### PR DESCRIPTION
# Summary
Update the Docker vulnerability scan action to allow write to the security events of the repo. This allows the scan results to be published.

This is required after the change to OIDC roles which narrowed the workflow permissions.