### PR TITLE
Change `get_object_age_seconds` to return 0 if the age would be in the future

### DIFF
--- a/tests/utils/test_store.py
+++ b/tests/utils/test_store.py
@@ -1,6 +1,5 @@
 import uuid
 from unittest import mock
-from datetime import timedelta
 
 from freezegun import freeze_time
 import pytest
@@ -169,12 +168,19 @@ def test_get_document_flagged_malicious(scan_files_store):
         scan_files_store.check_scan_verdict("service-id", "document-id", sending_method="link")
 
 
-@freeze_time("2023-02-17 16:00:00.000000")
-def test_get_object_age_seconds(scan_files_store):
+@pytest.mark.parametrize(
+    "last_modified, expected_age_seconds",
+    [
+        ("Fri, 17 Feb 2023 16:00:00 GMT", 60),
+        ("Fri, 17 Feb 2023 16:00:59 GMT", 1),
+        ("Fri, 17 Feb 2023 16:01:01 GMT", 0),
+    ],
+)
+@freeze_time("2023-02-17 16:01:00.000000")
+def test_get_object_age_seconds(scan_files_store, last_modified, expected_age_seconds):
     scan_files_store.s3.get_object_attributes = mock.Mock(
-        return_value={"ResponseMetadata": {"HTTPHeaders": {"last-modified": "Fri, 17 Feb 2023 15:05:00 GMT"}}}
+        return_value={"ResponseMetadata": {"HTTPHeaders": {"last-modified": last_modified}}}
     )
     age_data = scan_files_store.get_object_age_seconds("service-id", "document-id", sending_method="link")
     age_seconds = age_data["age_seconds"]
-    expected_seconds = timedelta(minutes=55).seconds
-    assert age_seconds == expected_seconds
+    assert age_seconds == expected_age_seconds


### PR DESCRIPTION
# Summary | Résumé

After adding more logging to troubleshoot the "scan files timing out" issue, we got the following log:
```
age_data: {
'age_seconds': 86399, 
'last_modified': 'Mon, 12 Jun 2023 23:39:05 GMT', 
'last_modified_parsed': datetime.datetime(2023, 6, 12, 23, 39, 5), 
'now': datetime.datetime(2023, 6, 12, 23, 39, 4, 605148), 
'utcnow': datetime.datetime(2023, 6, 12, 23, 39, 4, 605150), 
'age_vs_utcnow_seconds': 86399
}
```

The issue is that AWS is rounding to the nearest second, and that can make an s3 object appear to have been created in the future, and give us a large number back for the age in seconds (-1 day + 86399 seconds).

We can fix this and get the desired behaviour by just returning an age of 0 seconds if the object appears to have been created in the past.

# Test instructions | Instructions pour tester la modification

New tests should pass in CI.
