### PR TITLE
Prevent naming variations of .env files to be submited to git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,7 @@ environment.sh
 
 # Mac
 *.DS_Store
-.envrc
-.env
+.env*
 
 celerybeat-schedule
 
@@ -19,3 +18,5 @@ celerybeat-schedule
 
 /scripts/run_my_tests.sh
 .vscode
+
+!.env.example


### PR DESCRIPTION
# Summary | Résumé

Prevent naming variations of .env files to be submited to git.

# Test instructions | Instructions pour tester la modification

Create a file named `.env.staging` locally and check if it can get submitted with git.