### PR TITLE
Adding fail detection to k8s rollout

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -49,12 +49,7 @@ jobs:
 
     - name: Rollout in Kubernetes
       run: |
-        PAYLOAD={\"ref\":\"main\",\"inputs\":{\"docker_sha\":\"${GITHUB_SHA::7}\"}}
-        curl -L -X POST -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer $WORKFLOW_PAT" \
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/cds-snc/notification-manifests/actions/workflows/dd-api-rollout-k8s-staging.yaml/dispatches \
-          -d $PAYLOAD
+        ./scripts/callManifestsRollout.sh ${GITHUB_SHA::7}
 
     - name: my-app-install token
       id: notify-pr-bot

--- a/scripts/callManifestsRollout.sh
+++ b/scripts/callManifestsRollout.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+GITHUB_SHA=$1
+PAYLOAD="{\"ref\":\"main\",\"inputs\":{\"docker_sha\":\"$GITHUB_SHA\"}}"
+
+
+RESPONSE=$(curl -w '%{http_code}\n' \
+  -o /dev/null -s \
+  -L -X POST -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $WORKFLOW_PAT" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/cds-snc/notification-manifests/actions/workflows/dd-api-rollout-k8s-staging.yaml/dispatches \
+  -d "$PAYLOAD")
+
+if [ "$RESPONSE" != 204 ]; then
+  echo "ERROR CALLING MANIFESTS ROLLOUT: HTTP RESPONSE: $RESPONSE"
+  exit 1
+fi


### PR DESCRIPTION
# Summary | Résumé

Adding fault detection to docker k8s rollout workflow

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/293

# Test instructions | Instructions pour tester la modification

Ensure rollout job is still triggered

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
