### PR TITLE
Adding scratch back in

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -82,6 +82,7 @@ class Dev(Production):
 
 configs = {
     "test": Test,
+    "scratch": Scratch,
     "development": Development,
     "staging": Staging,
     "production": Production,


### PR DESCRIPTION
# Summary | Résumé

The scratch tag was missing from the allowed environments. Adding it back in.

## Related Issues | Cartes liées

Found while working on BCP

# Test instructions | Instructions pour tester la modification

Deploy to scratch.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
