### PR TITLE
Add monkeytype and poe the poet plugin for poetry

### DIFF
--- a/.devcontainer/scripts/notify-dev-entrypoint.sh
+++ b/.devcontainer/scripts/notify-dev-entrypoint.sh
@@ -15,6 +15,7 @@ echo -e "alias ls='exa'" >> ~/.zshrc
 echo -e "alias l='exa -alh'" >> ~/.zshrc
 echo -e "alias ll='exa -alh@ --git'" >> ~/.zshrc
 echo -e "alias lt='exa -al -T -L 2'" >> ~/.zshrc
+echo -e "alias poe='poetry run poe'" >> ~/.zshrc
 
 
 # Poetry autocomplete
@@ -28,5 +29,9 @@ pip install poetry==${POETRY_VERSION} \
 mkdir ~/.zfunc
 touch ~/.zfunc/_poetry
 poetry completions zsh > ~/.zfunc/_poetry
+
+# Poe the Poet plugin tab completions
+touch ~/.zfunc/_poe
+poetry run poe _zsh_completion > ~/.zfunc/_poe
 
 poetry install

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ celerybeat-schedule
 # CloudFoundry
 .cf
 
+# MonkeyType
+monkeytype.sqlite3
+
 /scripts/run_my_tests.sh
 .vscode
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -49,4 +49,11 @@ def create_app():
     application.register_blueprint(upload_blueprint)
     application.register_blueprint(healthcheck_blueprint)
 
+    # Specify packages to be traced by MonkeyType. This can be overriden
+    # via the MONKEYTYPE_TRACE_MODULES environment variable. e.g:
+    # MONKEYTYPE_TRACE_MODULES="app.,notifications_utils."
+    if application.config["NOTIFY_ENVIRONMENT"] == "development":
+        packages_prefix = ['app.','notifications_utils.']
+        application.monkeytype_config = MonkeytypeConfig(packages_prefix)
+
     return application

--- a/app/monkeytype_config.py
+++ b/app/monkeytype_config.py
@@ -1,0 +1,18 @@
+import os
+from monkeytype.config import DefaultConfig
+
+
+class MonkeytypeConfig(DefaultConfig):
+    def __init__(self, package_prefixes):
+        self.package_prefixes = package_prefixes
+
+    def code_filter(self, code):
+        # Get the module name from the code object
+        # and convert the file path to a module name
+        module_name = code.co_filname.replace(os.path.sep, '.')[:-3]
+
+        for prefix in self.package_prefixes:
+            if module_name.startswith(prefix):
+                return True
+
+        return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ black = "23.3.0"
 flake8 = "6.0.0"
 freezegun = "1.2.2"
 mypy = "1.0.1"
+monkeytype = "23.3.0"
+poethepoet = "^0.24.4"
 
 pytest = "7.2.0"
 pytest-env = "0.8.1"
@@ -54,3 +56,50 @@ types-requests = "2.28.11"
 coveralls = "1.11.1"
 
 jinja2-cli = { extras = ["yaml"], version = "0.8.2" }
+
+
+# Poe the Poet tasks
+[tool.poe.tasks.trace-app]
+help = "Runs the app with monkeytype type collection enabled."
+shell = """
+        monkeytype run -m flask run -p 7000 --host=0.0.0.0
+"""
+
+[tool.poe.tasks.trace-tests]
+help = "Runs a test suite or single test through MonkeyType, generating a record of type annotation traces monkeytype.sqlite3"
+shell = """
+    if [ -z "${method}" ]; then
+        monkeytype run -m pytest '/tests/app/${test-path}::${method}'
+    else
+        monkeytype run -m pytest '/tests/app/${test-path}'
+    fi
+"""
+    # Define arguments for trace-tests
+    [tool.poe.tasks.trace-tests.args.test-path]
+    help = "Path to the test file to run. /tests/app/ can be omitted. e.g. poe trace-tests -p main/test_contact.py"
+    options = ["-p", "--path"]
+    type = "string"
+    required = true
+
+    [tool.poe.tasks.trace-tests.args.method]
+    help = "Name of the test method to execute and trace"
+    options = ["-m", "--method"]
+    type = "string"
+    default = ""
+    required = false
+
+[tool.poe.tasks.list-modules]
+help = "Lists all files and modules that have trace data associated with them in monkeytype.sqlite3"
+cmd = "monkeytype list-modules"
+
+# Composite task that uses list-modules to obtain a list of files and modules
+[tool.poe.tasks.apply-annotations]
+help = "Applies ALL known type annotations stored in monkeytype.sqlite3"
+shell = """
+    for trace in ${TRACES}
+    do
+        monkeytype apply $trace
+    done
+"""
+deps = ["list-modules"]
+uses = { TRACES = "list-modules"}


### PR DESCRIPTION
# Summary | Résumé
This is an experimental PR that adds `monkeytype` and the Poetry plugin [Poe the Poet](https://poethepoet.natn.io/index.html) to the project.

## MonkeyType
[Monkeytype](https://github.com/Instagram/MonkeyType) collects runtime types of function arguments and return values, and can automatically generate stub files or even add draft type annotations directly to your Python code based on the types collected at runtime.

While it is very useful for automating the process of type annotating Python code bases, it is somewhat [cumbersome to work with manually](https://docs.google.com/document/d/1n_NgcL3QzPniakJEWUI1FYPFDuWUgzxTuf7Sahkpcdc/edit).

## Poe the Poet
Enter Poe the Poet, a task runner similar to `make` that provides a simple way to define project tasks directly in `pyproject.toml`. 

Leveraging features like [composite tasks and graphs](https://poethepoet.natn.io/guides/composition_guide.html#sequence-composition) we can create a rich, fully documented ecosystem of project specific tasks.

Since all `poe` tasks are run from within the Poetry virtual env by default, we no longer need to ask ourselves the question "Do I need `poetry run...` in front of this command?", nor would we need `poetry run` in front of nearly every command in our `makefile`.

This PR leverages the plugin to create a basic suite of tasks to simplify using `Monkeytype`. Just run `poe` or `poe --help` to list fully documented tasks:

```sh
CONFIGURED TASKS
  trace-tests        Runs a Python test file through MonkeyType, generating a record of type annotation traces. Traces are stored in monkeytype.sqlite3
    -p, --path       Path to the test file to run. /tests/app/ can be omitted. e.g. poe trace-tests -p main/test_contact.py
    -m, --method     Name of the test method to execute and trace
  list-traces        Lists all traces awaiting application from monkeytype.sqlite3
  apply-annotations  Applies ALL type annotations generated by trace-tests.
```

## Trying out MonkeyType via Poe the Poet tasks
1. Run `poe trace-tests -p main/test_contact.py` to generate type annotation traces for all code paths taken during each test in `test_contact.py`.
    - To collect traces from a single test in a file, run `poe trace-tests -p main/test_contact.py -m test_identity_step_logged_in`.
2. Note that after the task completes, a `monkeytype.sqlite3` file is generated. 
    - This DB file stores all the runtime types collected from the test(s) run in step 1.
3. Run `poe list-traces` to see all existing files and modules that MonkeyType collected types for.
4. Run `poe apply-annotations` to apply draft type annotations automagically to the code base.
5. Check your `git status` to review the type annotations that MonkeyType added.


## TODO
Fix issues with CI Dockerfiles