### PR TITLE
Add rust and cargo to dockerfile, bump alpine image

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.10-alpine3.16@sha256:afe68972cc00883d70b3760ee0ffbb7375cf09706c122dda7063ffe64c5be21b
+FROM python:3.10-alpine3.18@sha256:d5ee9613c89c9bd4c4112465d2136512ea8629bce6ff15fa27144f3cc16b5c6b
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ARG POETRY_VERSION="1.7.1"
 ENV POETRY_VIRTUALENVS_CREATE false
 
-RUN apk add --no-cache build-base git gcc make libffi-dev openssl-dev libmagic && rm -rf /var/cache/apk/*
+RUN apk add --no-cache build-base git gcc make libffi-dev openssl-dev libmagic rust cargo && rm -rf /var/cache/apk/*
 
 RUN pip3 install poetry==${POETRY_VERSION} \
   && poetry --version


### PR DESCRIPTION
# Summary | Résumé

Building `wheel` in ci needs `rustc` 1.70 or later but `alpine3.16`'s rust version is too low at 1.60 so just bumping the alpine image to 3.18.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-document-download-api/actions/runs/10836080844/job/30069011024

# Test instructions | Instructions pour tester la modification

Building the ci/Dockerfile locally should succeed `docker build -t docdl:dep-test -f ./ci/Dockerfile . --no-cache`

[Build, push to AWS ECR, and deploy](https://github.com/cds-snc/notification-document-download-api/actions/workflows/docker.yaml) action succeeds after merging.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
