### PR TITLE
Log the app config on startup

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,6 +9,7 @@ from app.config import configs
 from app.monkeytype_config import MonkeytypeConfig
 from app.utils.antivirus import AntivirusClient
 from app.utils.store import DocumentStore, ScanFilesDocumentStore
+from app.utils.logging import log_config
 
 document_store = DocumentStore()  # noqa: I001
 scan_files_document_store = ScanFilesDocumentStore()  # noqa: I001
@@ -42,6 +43,8 @@ def create_app():
 
     request_helper.init_app(application)
     logging.init_app(application)
+
+    log_config(application)
 
     document_store.init_app(application)
     scan_files_document_store.init_app(application)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,7 +9,6 @@ from app.config import configs
 from app.monkeytype_config import MonkeytypeConfig
 from app.utils.antivirus import AntivirusClient
 from app.utils.store import DocumentStore, ScanFilesDocumentStore
-from app.utils.logging import log_config
 
 document_store = DocumentStore()  # noqa: I001
 scan_files_document_store = ScanFilesDocumentStore()  # noqa: I001
@@ -38,13 +37,14 @@ class Base64UUIDConverter(BaseConverter):
 def create_app():
     application = Flask("app", static_folder=None)
     application.config.from_object(configs[os.environ["NOTIFY_ENVIRONMENT"]])
+    config = configs[os.environ["NOTIFY_ENVIRONMENT"]]
 
     application.url_map.converters["base64_uuid"] = Base64UUIDConverter
 
     request_helper.init_app(application)
     logging.init_app(application)
 
-    log_config(application)
+    application.logger.info(f"Notify config: {config.get_safe_config()}")
 
     document_store.init_app(application)
     scan_files_document_store.init_app(application)

--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any
 
 from dotenv import load_dotenv
 from flask_env import MetaFlaskEnv
@@ -42,6 +43,30 @@ class Config(metaclass=MetaFlaskEnv):
 
     ANTIVIRUS_API_HOST = os.getenv("ANTIVIRUS_API_HOST", "http://localhost:6016")
     ANTIVIRUS_API_KEY = os.getenv("ANTIVIRUS_API_KEY", "")
+
+    @classmethod
+    def get_sensitive_config(cls) -> list[str]:
+        "List of config keys that contain sensitive information"
+        return [
+            "SECRET_KEY",
+            "AUTH_TOKENS",
+            "ANTIVIRUS_API_KEY",
+        ]
+
+    @classmethod
+    def get_config(cls, sensitive_config: list[str]) -> dict[str, Any]:
+        "Returns a dict of config keys and values"
+        config = {}
+        for attr in dir(cls):
+            attr_value = "***" if attr in sensitive_config else getattr(cls, attr)
+            if not attr.startswith("__") and not callable(attr_value):
+                config[attr] = attr_value
+        return config
+
+    @classmethod
+    def get_safe_config(cls) -> dict[str, Any]:
+        "Returns a dict of config keys and values with sensitive values masked"
+        return cls.get_config(cls.get_sensitive_config())
 
 
 class Test(Config):

--- a/app/config.py
+++ b/app/config.py
@@ -2,13 +2,16 @@ import os
 from typing import Any
 
 from dotenv import load_dotenv
+from environs import Env
 from flask_env import MetaFlaskEnv
 
+env = Env()
+env.read_env()
 load_dotenv()
 
 
 class Config(metaclass=MetaFlaskEnv):
-    DEBUG = os.getenv("DEBUG", False)
+    DEBUG = env.bool("DEBUG", False)
 
     SECRET_KEY = os.getenv("SECRET_KEY", "secret-key")
     AUTH_TOKENS = os.getenv("AUTH_TOKENS", "auth-token")

--- a/app/utils/logging.py
+++ b/app/utils/logging.py
@@ -1,9 +1,0 @@
-def log_config(app):
-    "A function to log the configuration values of the app on startup"
-    do_not_log = ["SECRET_KEY", "AUTH_TOKENS", "ANTIVIRUS_API_KEY"]
-    for key in app.config:
-        if key in do_not_log:
-            continue
-        app.logger.info(
-            f"Config value: {key}={app.config[key]}"
-        )

--- a/app/utils/logging.py
+++ b/app/utils/logging.py
@@ -1,0 +1,9 @@
+def log_config(app):
+    "A function to log the configuration values of the app on startup"
+    do_not_log = ["SECRET_KEY", "AUTH_TOKENS", "ANTIVIRUS_API_KEY"]
+    for key in app.config:
+        if key in do_not_log:
+            continue
+        app.logger.info(
+            f"Config value: {key}={app.config[key]}"
+        )

--- a/poetry.lock
+++ b/poetry.lock
@@ -540,6 +540,26 @@ files = [
 ]
 
 [[package]]
+name = "environs"
+version = "11.2.1"
+description = "simplified environment variable parsing"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "environs-11.2.1-py3-none-any.whl", hash = "sha256:9d2080cf25807a26fc0d4301e2d7b62c64fbf547540f21e3a30cc02bc5fbe948"},
+    {file = "environs-11.2.1.tar.gz", hash = "sha256:e068ae3174cef52ba4b95ead22e639056a02465f616e62323e04ae08e86a75a4"},
+]
+
+[package.dependencies]
+marshmallow = ">=3.13.0"
+python-dotenv = "*"
+
+[package.extras]
+dev = ["environs[tests]", "pre-commit (>=3.5,<5.0)", "tox"]
+django = ["dj-database-url", "dj-email-url", "django-cache-url"]
+tests = ["environs[django]", "pytest"]
+
+[[package]]
 name = "filelock"
 version = "3.16.1"
 description = "A platform independent file lock."
@@ -988,6 +1008,25 @@ files = [
     {file = "MarkupSafe-2.1.5-cp39-cp39-win_amd64.whl", hash = "sha256:fa173ec60341d6bb97a89f5ea19c85c5643c1e7dedebc22f5181eb73573142c5"},
     {file = "MarkupSafe-2.1.5.tar.gz", hash = "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b"},
 ]
+
+[[package]]
+name = "marshmallow"
+version = "3.23.2"
+description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "marshmallow-3.23.2-py3-none-any.whl", hash = "sha256:bcaf2d6fd74fb1459f8450e85d994997ad3e70036452cbfa4ab685acb19479b3"},
+    {file = "marshmallow-3.23.2.tar.gz", hash = "sha256:c448ac6455ca4d794773f00bae22c2f351d62d739929f761dce5eacb5c468d7f"},
+]
+
+[package.dependencies]
+packaging = ">=17.0"
+
+[package.extras]
+dev = ["marshmallow[tests]", "pre-commit (>=3.5,<5.0)", "tox"]
+docs = ["alabaster (==1.0.0)", "autodocsumm (==0.2.14)", "sphinx (==8.1.3)", "sphinx-issues (==5.0.0)", "sphinx-version-warning (==1.1.2)"]
+tests = ["pytest", "simplejson"]
 
 [[package]]
 name = "mistune"
@@ -2009,4 +2048,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12.7"
-content-hash = "509a8012898030a7211132b4920cc8968b468e0b6ea82a8f7ede791686abfc6d"
+content-hash = "ffeac0c302e8cc99d23a9b97b4bbd61e54a16c6fd12d9eda340ee396ffa9fb49"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ python = "~3.12.7"
 aws-xray-sdk = "^2.14.0"
 
 awscli-cwlogs = "1.4.6"
+environs = "^11.2.1"
 Flask = "2.3.3"
 Flask-Env = "2.0.0"
 gevent = "24.2.1"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,48 @@
+import importlib
+import os
+
+import pytest
+from app import config
+
+
+@pytest.fixture
+def reload_config():
+    """
+    Reset config, by simply re-running config.py from a fresh environment
+    """
+    old_env = os.environ.copy()
+    yield
+    os.environ = old_env
+    importlib.reload(config)
+
+
+def test_get_config(reload_config):
+    config.Config.DOCUMENTS_BUCKET = "test-documents-bucket"
+    config.Config.SCAN_FILES_DOCUMENTS_BUCKET = "test-scan-files-bucket"
+    logged_config = config.Config.get_config([])
+    assert logged_config["DOCUMENTS_BUCKET"] == "test-documents-bucket"
+    assert logged_config["SCAN_FILES_DOCUMENTS_BUCKET"] == "test-scan-files-bucket"
+
+    config.Config.SECRET_KEY = "1234"
+    logged_config = config.Config.get_config(["SECRET_KEY"])
+    assert logged_config["SECRET_KEY"] == "***"
+
+    for key, _ in logged_config.items():
+        assert not key.startswith("__")
+        assert not callable(getattr(config.Config, key))
+
+
+def test_get_safe_config(mocker, reload_config):
+    mock_get_config = mocker.patch("app.config.Config.get_config")
+    mock_get_sensitive_config = mocker.patch("app.config.Config.get_sensitive_config")
+
+    config.Config.get_safe_config()
+    assert mock_get_config.called
+    assert mock_get_sensitive_config.called
+
+
+def get_sensitive_config():
+    sensitive_config = config.Config.get_sensitive_config()
+    assert sensitive_config
+    for key in sensitive_config:
+        assert key


### PR DESCRIPTION
# Summary | Résumé

This commit makes the following changes:
- the config values are now logged when the app starts up, with sensitive values masked
- this is implemented as new class methods on the existing `Config` class
- new tests added to verify this is working correctly
- add the `environs` package to force the `DEBUG` config value to be boolean

This PR shamelessly copies what @patheard did over in [this pr](https://github.com/cds-snc/notification-api/pull/1501) to implement the same feature in `notification-api`.

## Related Issues | Cartes liées

https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/504

# Test instructions | Instructions pour tester la modification

Test locally to ensure you can see the config values being logged.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

