### PR TITLE
Updating Docker Image Tags for Helm Release Process

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -8,7 +8,6 @@ env:
   AWS_REGION: ca-central-1
   DOCKER_ORG: public.ecr.aws/cds-snc
   DOCKER_SLUG: public.ecr.aws/cds-snc/notify-document-download-api
-  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING }}
 
 permissions:
   id-token: write   # This is required for requesting the OIDC JWT
@@ -52,15 +51,7 @@ jobs:
       with:
         role-to-assume: arn:aws:iam::239043911459:role/notification-document-download-api-apply
         role-session-name: NotifyDocumentDownloadApiGitHubActions
-        aws-region: "ca-central-1"
-
-    - name: Setup Terraform tools
-      uses: cds-snc/terraform-tools-setup@v1
-      env: # In case you want to override default versions
-        CONFTEST_VERSION: 0.30.0 
-        TERRAFORM_VERSION: 1.9.5
-        TERRAGRUNT_VERSION: 0.66.9
-        TF_SUMMARIZE_VERSION: 0.2.3                           
+        aws-region: "ca-central-1"                      
 
     - name: Set Docker Tag
       run: echo "DOCKER_TAG=${GITHUB_SHA::7}" >> $GITHUB_ENV

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -54,16 +54,6 @@ jobs:
         role-session-name: NotifyDocumentDownloadApiGitHubActions
         aws-region: "ca-central-1"
 
-    - name: Install OpenVPN
-      run: |
-        sudo apt update
-        sudo apt install -y openvpn openvpn-systemd-resolved
-
-    - name: Install 1Pass CLI
-      run: |
-        curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
-        sudo dpkg -i 1pass.deb
-
     - name: Setup Terraform tools
       uses: cds-snc/terraform-tools-setup@v1
       env: # In case you want to override default versions
@@ -72,23 +62,20 @@ jobs:
         TERRAGRUNT_VERSION: 0.66.9
         TF_SUMMARIZE_VERSION: 0.2.3                           
 
-    - name: Fetch VPN
+    - name: Set Docker Tag
+      run: echo "DOCKER_TAG=${GITHUB_SHA::7}" >> $GITHUB_ENV
+      env:
+        GITHUB_SHA: ${{ github.sha }}
+  
+    - name: Update images in staging (Helm)
       run: |
-        curl https://raw.githubusercontent.com/cds-snc/notification-manifests/refs/heads/main/scripts/createVPNConfig.sh | bash -s staging
-
-    - name: Connect to VPN
-      uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5"
-      with:
-        config_file: /var/tmp/staging.ovpn
-        echo_config: false      
-
-    - name: Get Kubernetes configuration
-      run: |
-        aws eks --region $AWS_REGION update-kubeconfig --name notification-canada-ca-staging-eks-cluster --kubeconfig $HOME/.kube/config
-
-    - name: Update image in staging
-      run: |
-        kubectl set image deployment.apps/notify-document-download notify-document-download=$DOCKER_SLUG:${GITHUB_SHA::7} -n=notification-canada-ca --kubeconfig=$HOME/.kube/config
+        curl -L \
+        -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.MANIFESTS_WORKFLOW_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/cds-snc/notification-manifests/dispatches \
+          -d '{"event_type":"update-docker-image","client_payload":{"component":"DOCUMENT_DOWNLOAD","docker_tag":"${{ env.DOCKER_TAG }}"}}'
 
     - name: my-app-install token
       id: notify-pr-bot


### PR DESCRIPTION
# Summary | Résumé

Adding a workflow that runs on merge to main, calls a workflow in manifests to update the docker image tag in our manifests configuration files.

# Test instructions | Instructions pour tester la modification

> watch that this runs on merge to main, and then check to see if the file has been updated in manifests here: 
https://github.com/cds-snc/notification-manifests/blob/main/helmfile/overrides/staging.env

## Related Issues | Cartes liées
https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/491


# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.