### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.devcontainer/scripts/notify-dev-entrypoint.sh
+++ b/.devcontainer/scripts/notify-dev-entrypoint.sh
@@ -33,6 +33,9 @@ mkdir ~/.zfunc
 touch ~/.zfunc/_poetry
 poetry completions zsh > ~/.zfunc/_poetry
 
+# Set up git blame to ignore certain revisions e.g. sweeping code formatting changes.
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+
 poetry install
 
 # Poe the Poet plugin tab completions

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,9 @@
+##################################################################
+## This file lists commits that should be ignored by git blame. ##
+## e.g. Formatting commits, non-functional changes, etc.        ##
+##################################################################
+
+# Black formatter https://github.com/cds-snc/notification-document-download-api/commit/d69bb99eb72fd6a7f92dc952ddf41dec495147f8
+d69bb99eb72fd6a7f92dc952ddf41dec495147f8
+# Ruff formatter https://github.com/cds-snc/notification-document-download-api/commit/6026d95143fb58fbd849b1d39bca7b8b76123430
+6026d95143fb58fbd849b1d39bca7b8b76123430


### PR DESCRIPTION
# Summary | Résumé
This PR adds [`.git-blame-ignore-revs`](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view) to the project. This lets us to filter out specified commits when using git blame, e.g. bulk formatting and other changes that do not affect functionality.

To ignore a commit, just add the commit SHA to [.git-blame-ignore-revs](https://github.com/cds-snc/notification-document-download-api/pull/210/files#diff-f247fbfbe928b907db42554d0b3006b28dd11c25a59be031abda73b11a2c934a)

# Test instructions | Instructions pour tester la modification
1. Open `.git-blame-ignore-revs` and open one of the links to an ignored commit.
2. Open a file that the ignored commit changed and run git blame.
3. Note that the ignored commits are not present and the commit previous is shown instead.

## After this PR is merged
- [ ] Repeat the above steps but open the file on the Github website and open the blame tool
- [ ] The excluded commits are not present on the web version
- [ ] Appending a `~` to the commit SHA in the URL shows the ignored commits