### PR TITLE
fix: correct MIME type detection for OOXML files (.xlsx, .docx, .pptx)

### DIFF
--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -38,6 +38,18 @@ def upload_document(service_id):
     if (filename or "").lower().endswith(".csv") and mimetype == "text/plain":
         mimetype = "text/csv"
 
+    # OOXML formats (.xlsx, .docx, .pptx) are ZIP containers and are detected
+    # as application/zip by libmagic. Override using the filename extension,
+    # consistent with the CSV fix above.
+    if (filename or "").lower().endswith(".xlsx") and mimetype == "application/zip":
+        mimetype = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+    if (filename or "").lower().endswith(".docx") and mimetype == "application/zip":
+        mimetype = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+
+    if (filename or "").lower().endswith(".pptx") and mimetype == "application/zip":
+        mimetype = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+
     sending_method = request.form.get("sending_method")
 
     document = document_store.put(service_id, file_content, sending_method=sending_method, mimetype=mimetype)


### PR DESCRIPTION
# Summary

Sending an `.xlsx` file as an email attachment via the GC Notify API fails with a `400 BadRequestError` claiming the file type is unsupported, despite `.xlsx` being explicitly documented as a supported format.

**Root cause:** The `notification-document-download-api` uses `libmagic` to detect MIME types. Because the OOXML format (`.xlsx`, `.docx`, `.pptx`) is a ZIP container internally, `libmagic` returns `application/zip` for all three. `application/zip` is not in `ALLOWED_MIME_TYPES`, so the upload is rejected — even though `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` appears in the allowlist.

**Fix:** Add filename-extension overrides immediately after the existing `.csv` fix in `app/upload/views.py`, using the identical pattern already established in this codebase.

### What the documentation says

From [Sending files by email](https://documentation.notification.canada.ca/en/send.html#sending-files-by-email):

> "You can upload .pdf, .csv, .jpeg, .png, .odt, .txt, .rtf, as well as **Microsoft Excel** and Microsoft Word files."

The error codes table on the same page lists `.xlsx` explicitly as a supported type in the fix guidance for `BadRequestError`.

### Actual API response

```json
{
  "error": "BadRequestError",
  "message": "Unsupported document type 'application/zip'. Supported types are: [..., 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', ...]"
}
```

Note that the correct MIME type is present in the allowlist — the file is rejected solely because `libmagic` misidentifies it as `application/zip`.

## Related Issues

N/A — externally reported against `cds-snc/notification-api`; fix lives here.

# Test Instructions

1. Generate a valid `.xlsx` file (e.g. via Python `openpyxl`)
2. Base64-encode it and send via `POST /v2/notifications/email` with `sending_method: attach`
3. Before this fix: `400 BadRequestError: Unsupported document type 'application/zip'`
4. After this fix: file is accepted and attached to the email

Same test applies for `.docx` and `.pptx`.

# Release Instructions

No migration or configuration changes required.

# Reviewer Checklist

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered.